### PR TITLE
Request Client certificate during TLS Handshake

### DIFF
--- a/server.go
+++ b/server.go
@@ -56,6 +56,8 @@ func (s *SyncTlsConfig) setTlsConfig(sslKeys []*SSLPair, cipherSuites []uint16, 
 		tlsConfig.CipherSuites = cipherSuites
 	}
 
+	tlsConfig.ClientAuth = tls.RequestClientCert
+
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.tlsConfig = tlsConfig
@@ -188,7 +190,7 @@ func (s *Server) Run() error {
 			}
 
 			remoteAddr := conn.RemoteAddr()
-			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), ""}
+			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), "", nil}
 			if _, ok := s.contextualWorkerFactory(); ok {
 				s.sessionManager.sessionWG.Add(1)
 			}

--- a/session.go
+++ b/session.go
@@ -20,7 +20,7 @@ type Session struct {
 	logger *slogger.Logger
 
 	SSLServerName string
-	tlsConn *tls.Conn
+	tlsConn       *tls.Conn
 }
 
 var ErrUnknownOpcode = errors.New("unknown opcode")

--- a/session.go
+++ b/session.go
@@ -20,6 +20,7 @@ type Session struct {
 	logger *slogger.Logger
 
 	SSLServerName string
+	tlsConn *tls.Conn
 }
 
 var ErrUnknownOpcode = errors.New("unknown opcode")
@@ -27,6 +28,10 @@ var ErrUnknownOpcode = errors.New("unknown opcode")
 // ------------------
 func (s *Session) Connection() io.ReadWriteCloser {
 	return s.conn
+}
+
+func (s *Session) GetTLSConnection() *tls.Conn {
+	return s.tlsConn
 }
 
 func (s *Session) Logf(level slogger.Level, messageFmt string, args ...interface{}) (*slogger.Log, []error) {
@@ -67,6 +72,7 @@ func (s *Session) Run(conn net.Conn) {
 			s.logger.Logf(slogger.WARN, "error doing tls handshake %s", err)
 			return
 		}
+		s.tlsConn = c
 		s.SSLServerName = strings.TrimSuffix(c.ConnectionState().ServerName, ".")
 	}
 


### PR DESCRIPTION
During TLS handshake, client will provide client cert if available. We will store that cert as part of tcp connection data structure