### PR TITLE
Handle SDAM errors

### DIFF
--- a/inttests/run_integration_tests_mongod_mode.sh
+++ b/inttests/run_integration_tests_mongod_mode.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -vx
 
 echo ### RUNNING INTEGRATION TESTS
 # If you do no set MONGO_DIR on the command line it will default to the value below

--- a/inttests/run_integration_tests_mongos_mode.sh
+++ b/inttests/run_integration_tests_mongos_mode.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -vx
 
 echo ### RUNNING INTEGRATION TESTS
 # If you do no set MONGO_DIR on the command line it will default to the value below

--- a/proxy.go
+++ b/proxy.go
@@ -500,6 +500,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		err = SendMessage(resp, ps.conn)
 		if err != nil {
 			mongoConn.bad = true
+			logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
 			return nil, NewStackErrorf("got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
 		}
 		logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sent back data to user from mongo conn %v", mongoConn.conn.ID())

--- a/proxy.go
+++ b/proxy.go
@@ -564,8 +564,7 @@ func getMongoClient(p *Proxy, pc ProxyConfig, ctx context.Context) (*mongo.Clien
 				}
 			},
 		}).
-		SetServerSelectionTimeout(time.Duration(pc.ServerSelectionTimeoutSec) * time.Second).
-		SetMaxPoolSize(0)
+		SetServerSelectionTimeout(time.Duration(pc.ServerSelectionTimeoutSec) * time.Second)
 
 	if pc.MongoUser != "" {
 		auth := options.Credential{

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -23,6 +23,7 @@ const (
 	ServerSelectionTimeoutSecForTests = 10
 	ParallelClients                   = 5
 	InterruptedAtShutdownErrorCode    = 11600
+	ClientTimeoutSec                  = 30 * time.Second
 )
 
 type MyFactory struct {
@@ -227,7 +228,7 @@ func runCommandFailOp(host string, proxyPort int, mode MongoConnectionMode, seco
 	if err != nil {
 		return err
 	}
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), ClientTimeoutSec)
 	defer cancelFunc()
 	if err := client.Connect(ctx); err != nil {
 		return fmt.Errorf("cannot connect to server. err: %v", err)
@@ -242,7 +243,7 @@ func runOp(host string, proxyPort, iteration int, shouldFail bool, mode MongoCon
 	if err != nil {
 		return err
 	}
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), ClientTimeoutSec)
 	defer cancelFunc()
 	if err := client.Connect(ctx); err != nil {
 		return fmt.Errorf("cannot connect to server. err: %v", err)
@@ -291,7 +292,7 @@ func enableFailPointCloseConnection(host string, mongoPort int, mode MongoConnec
 	if err != nil {
 		return err
 	}
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), ClientTimeoutSec)
 	defer cancelFunc()
 	if err := client.Connect(ctx); err != nil {
 		return fmt.Errorf("cannot connect to server. err: %v", err)
@@ -314,7 +315,7 @@ func enableFailPointErrorCode(host string, mongoPort, errorCode int, mode MongoC
 	if err != nil {
 		return err
 	}
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), ClientTimeoutSec)
 	defer cancelFunc()
 	if err := client.Connect(ctx); err != nil {
 		return fmt.Errorf("cannot connect to server. err: %v", err)
@@ -337,7 +338,7 @@ func disableFailPoint(host string, mongoPort int, mode MongoConnectionMode) erro
 	if err != nil {
 		return err
 	}
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), ClientTimeoutSec)
 	defer cancelFunc()
 	if err := client.Connect(ctx); err != nil {
 		return fmt.Errorf("cannot connect to server. err: %v", err)
@@ -406,6 +407,7 @@ func getHostAndPorts() (mongoPort, proxyPort int, hostname string) {
 
 func privateTestMongodMode(secondaryMode bool, t *testing.T) {
 	mongoPort, proxyPort, _ := getHostAndPorts()
+	t.Logf("using proxy port %v", proxyPort)
 	if err := disableFailPoint("localhost", mongoPort, Direct); err != nil {
 		t.Fatalf("failed to disable failpoint. err=%v", err)
 		return
@@ -425,6 +427,7 @@ func TestProxySanityMongodModeSecondary(t *testing.T) {
 
 func privateTestMongosMode(secondaryMode bool, t *testing.T) {
 	mongoPort, proxyPort, hostname := getHostAndPorts()
+	t.Logf("using proxy port %v", proxyPort)
 	if err := disableFailPoint(hostname, mongoPort, Cluster); err != nil {
 		t.Fatalf("failed to disable failpoint. err=%v", err)
 		return

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -486,8 +486,8 @@ func privateTester(t *testing.T, pc ProxyConfig, host string, proxyPort, mongoPo
 		return
 	}
 	conns = proxy.GetConnectionsCreated()
-	if conns != currConns {
-		t.Fatalf("expected connections created to remain the same (%v), but got %v", currConns, conns)
+	if conns-int64(currConns) > int64(parallelism) {
+		t.Fatalf("expected connections created to not significantly increase (%v), but got %v", currConns, conns)
 	}
 	currConns = conns
 	if cleared := proxy.GetPoolCleared(); cleared != 0 {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -23,7 +23,7 @@ const (
 	ServerSelectionTimeoutSecForTests = 10
 	ParallelClients                   = 5
 	InterruptedAtShutdownErrorCode    = 11600
-	ClientTimeoutSec                  = time.Minute
+	ClientTimeoutSec                  = 10 * time.Second
 )
 
 type MyFactory struct {
@@ -366,11 +366,14 @@ func runOps(host string, proxyPort, parallelism int, shouldFail bool, t *testing
 		wg.Add(1)
 		go func(iteration int) {
 			defer wg.Done()
+			start := time.Now()
+			t.Logf("*** %v started running worker %v", start, iteration)
 			err := runOp(host, proxyPort, iteration, shouldFail, mode, secondaryReads)
 			if err != nil {
 				t.Error(err)
 				atomic.AddInt32(&failing, 1)
 			}
+			t.Logf("*** %v finished running worker %v in %vms. err=%v", time.Now(), iteration, time.Since(start), err)
 		}(i)
 	}
 	wg.Wait()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -23,7 +23,7 @@ const (
 	ServerSelectionTimeoutSecForTests = 10
 	ParallelClients                   = 5
 	InterruptedAtShutdownErrorCode    = 11600
-	ClientTimeoutSec                  = 30 * time.Second
+	ClientTimeoutSec                  = time.Minute
 )
 
 type MyFactory struct {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	ServerSelectionTimeoutSecForTests = 5
 	ParallelClients                   = 5
-	InterruptedAtShutdownErrorCode    = 11660
+	ShutdownInProgressErrorCode       = 91
 )
 
 type MyFactory struct {
@@ -503,7 +503,7 @@ func privateTester(t *testing.T, pc ProxyConfig, host string, proxyPort, mongoPo
 	}
 
 	t.Log("*** enable error code response failpoint and run ops")
-	enableFailPointErrorCode(host, mongoPort, InterruptedAtShutdownErrorCode, mode)
+	enableFailPointErrorCode(host, mongoPort, ShutdownInProgressErrorCode, mode)
 	failing = runOps(host, proxyPort, parallelism, true, t, mode, secondaryReads)
 	if atomic.LoadInt32(&failing) > 0 {
 		t.Fatalf("ops failures")

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -373,7 +373,7 @@ func runOps(host string, proxyPort, parallelism int, shouldFail bool, t *testing
 				t.Error(err)
 				atomic.AddInt32(&failing, 1)
 			}
-			t.Logf("*** %v finished running worker %v in %vms. err=%v", time.Now(), iteration, time.Since(start), err)
+			t.Logf("*** %v finished running worker %v in %v. err=%v", time.Now(), iteration, time.Since(start), err)
 		}(i)
 	}
 	wg.Wait()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	ServerSelectionTimeoutSecForTests = 10
 	ParallelClients                   = 5
-	ShutdownInProgressErrorCode       = 91
+	InterruptedAtShutdownErrorCode    = 11600
 )
 
 type MyFactory struct {
@@ -503,7 +503,7 @@ func privateTester(t *testing.T, pc ProxyConfig, host string, proxyPort, mongoPo
 	}
 
 	t.Log("*** enable error code response failpoint and run ops")
-	enableFailPointErrorCode(host, mongoPort, ShutdownInProgressErrorCode, mode)
+	enableFailPointErrorCode(host, mongoPort, InterruptedAtShutdownErrorCode, mode)
 	failing = runOps(host, proxyPort, parallelism, true, t, mode, secondaryReads)
 	if atomic.LoadInt32(&failing) > 0 {
 		t.Fatalf("ops failures")

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -23,7 +23,7 @@ const (
 	ServerSelectionTimeoutSecForTests = 10
 	ParallelClients                   = 5
 	InterruptedAtShutdownErrorCode    = 11600
-	ClientTimeoutSec                  = 10 * time.Second
+	ClientTimeoutSec                  = 20 * time.Second
 )
 
 type MyFactory struct {
@@ -533,7 +533,7 @@ func privateTester(t *testing.T, pc ProxyConfig, host string, proxyPort, mongoPo
 		t.Fatalf("ops failures")
 		return
 	}
-	if cleared2 := proxy.GetPoolCleared(); cleared2 < cleared2 {
+	if cleared2 := proxy.GetPoolCleared(); cleared2 < cleared {
 		t.Fatalf("expected pool cleared to be gt previous value but was %v", cleared2)
 	}
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -351,7 +351,10 @@ func getProxyConfig(hostname string, mongoPort, proxyPort int, mode MongoConnect
 func getHostAndPorts() (mongoPort, proxyPort int, hostname string) {
 	var err error
 	mongoPort = 30000
-	proxyPort = 9900
+	proxyPort, err = EphemeralPort()
+	if err != nil {
+		panic(err)
+	}
 	if os.Getenv("MONGO_PORT") != "" {
 		mongoPort, _ = strconv.Atoi(os.Getenv("MONGO_PORT"))
 	}

--- a/session.go
+++ b/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mongodb/slogger/v2/slogger"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 type Session struct {
@@ -139,6 +140,7 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 			0, // StartingFrom
 			1, // NumberReturned
 			[]SimpleBSON{doc},
+			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 
@@ -172,6 +174,7 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 					doc,
 				},
 			},
+			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 
@@ -214,6 +217,7 @@ func (s *Session) RespondWithError(clientMessage Message, err error) error {
 			0, // StartingFrom
 			1, // NumberReturned
 			[]SimpleBSON{doc},
+			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 
@@ -247,6 +251,7 @@ func (s *Session) RespondWithError(clientMessage Message, err error) error {
 					doc,
 				},
 			},
+			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,0 +1,43 @@
+package mongonet
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func EphemeralPort() (int, error) {
+	fd, err := syscall.Socket(
+		syscall.AF_INET,
+		syscall.SOCK_STREAM,
+		syscall.IPPROTO_TCP,
+	)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to obtain socket. err=%v", err)
+	}
+
+	defer syscall.Close(fd)
+
+	err = syscall.Bind(
+		fd,
+		&syscall.SockaddrInet4{
+			Port: 0,                   // 0 requests that the kernel assign an ephemeral port
+			Addr: [4]byte{0, 0, 0, 0}, // 0.0.0.0 means any IP address
+		},
+	)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to bind socket. err=%v", err)
+	}
+
+	var sockaddr syscall.Sockaddr
+	sockaddr, err = syscall.Getsockname(fd)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to Getsockname() for fd %v. err=%v", fd, err)
+	}
+
+	sockaddr4, ok := sockaddr.(*syscall.SockaddrInet4)
+	if !ok {
+		return -1, fmt.Errorf("Expected *syscall.SockaddrInet4 from Getsockname(), but got %#v", sockaddr)
+	}
+
+	return sockaddr4.Port, nil
+}

--- a/util.go
+++ b/util.go
@@ -1,8 +1,15 @@
 package mongonet
 
-import "fmt"
-import "runtime"
-import "strings"
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
+)
 
 // ---
 
@@ -52,4 +59,152 @@ func stripDirectories(filepath string, toKeep int) string {
 	}
 
 	return filepath[idxCutoff+1:]
+}
+
+func extractError(rdr bsoncore.Document) error {
+	var errmsg, codeName string
+	var code int32
+	var labels []string
+	var ok bool
+	var tv *description.TopologyVersion
+	var wcError driver.WriteCommandError
+	elems, err := rdr.Elements()
+	if err != nil {
+		return err
+	}
+
+	for _, elem := range elems {
+		switch elem.Key() {
+		case "ok":
+			switch elem.Value().Type {
+			case bson.TypeInt32:
+				if elem.Value().Int32() == 1 {
+					ok = true
+				}
+			case bson.TypeInt64:
+				if elem.Value().Int64() == 1 {
+					ok = true
+				}
+			case bson.TypeDouble:
+				if elem.Value().Double() == 1 {
+					ok = true
+				}
+			}
+		case "errmsg":
+			if str, okay := elem.Value().StringValueOK(); okay {
+				errmsg = str
+			}
+		case "codeName":
+			if str, okay := elem.Value().StringValueOK(); okay {
+				codeName = str
+			}
+		case "code":
+			if c, okay := elem.Value().Int32OK(); okay {
+				code = c
+			}
+		case "errorLabels":
+			if arr, okay := elem.Value().ArrayOK(); okay {
+				elems, err := arr.Elements()
+				if err != nil {
+					continue
+				}
+				for _, elem := range elems {
+					if str, ok := elem.Value().StringValueOK(); ok {
+						labels = append(labels, str)
+					}
+				}
+
+			}
+		case "writeErrors":
+			arr, exists := elem.Value().ArrayOK()
+			if !exists {
+				break
+			}
+			vals, err := arr.Values()
+			if err != nil {
+				continue
+			}
+			for _, val := range vals {
+				var we driver.WriteError
+				doc, exists := val.DocumentOK()
+				if !exists {
+					continue
+				}
+				if index, exists := doc.Lookup("index").AsInt64OK(); exists {
+					we.Index = index
+				}
+				if code, exists := doc.Lookup("code").AsInt64OK(); exists {
+					we.Code = code
+				}
+				if msg, exists := doc.Lookup("errmsg").StringValueOK(); exists {
+					we.Message = msg
+				}
+				wcError.WriteErrors = append(wcError.WriteErrors, we)
+			}
+		case "writeConcernError":
+			doc, exists := elem.Value().DocumentOK()
+			if !exists {
+				break
+			}
+			wcError.WriteConcernError = new(driver.WriteConcernError)
+			if code, exists := doc.Lookup("code").AsInt64OK(); exists {
+				wcError.WriteConcernError.Code = code
+			}
+			if name, exists := doc.Lookup("codeName").StringValueOK(); exists {
+				wcError.WriteConcernError.Name = name
+			}
+			if msg, exists := doc.Lookup("errmsg").StringValueOK(); exists {
+				wcError.WriteConcernError.Message = msg
+			}
+			if info, exists := doc.Lookup("errInfo").DocumentOK(); exists {
+				wcError.WriteConcernError.Details = make([]byte, len(info))
+				copy(wcError.WriteConcernError.Details, info)
+			}
+			if errLabels, exists := doc.Lookup("errorLabels").ArrayOK(); exists {
+				elems, err := errLabels.Elements()
+				if err != nil {
+					continue
+				}
+				for _, elem := range elems {
+					if str, ok := elem.Value().StringValueOK(); ok {
+						labels = append(labels, str)
+					}
+				}
+			}
+		case "topologyVersion":
+			doc, ok := elem.Value().DocumentOK()
+			if !ok {
+				break
+			}
+			// original line was version, err := description.NewTopologyVersion(bson.Raw(doc))
+			version, err := description.NewTopologyVersion(doc)
+			if err == nil {
+				tv = version
+			}
+		}
+	}
+
+	if !ok {
+		if errmsg == "" {
+			errmsg = "command failed"
+		}
+
+		return driver.Error{
+			Code:            code,
+			Message:         errmsg,
+			Name:            codeName,
+			Labels:          labels,
+			TopologyVersion: tv,
+		}
+	}
+
+	if len(wcError.WriteErrors) > 0 || wcError.WriteConcernError != nil {
+		wcError.Labels = labels
+		if wcError.WriteConcernError != nil {
+			wcError.WriteConcernError.TopologyVersion = tv
+		}
+		return wcError
+	}
+
+	return nil
 }

--- a/wire.go
+++ b/wire.go
@@ -1,5 +1,7 @@
 package mongonet
 
+import "go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+
 const (
 	OP_REPLY         = 1
 	OP_MSG_LEGACY    = 1000
@@ -47,7 +49,8 @@ type ReplyMessage struct {
 	StartingFrom   int32
 	NumberReturned int32
 
-	Docs []SimpleBSON
+	Docs       []SimpleBSON
+	CommandDoc bsoncore.Document
 }
 
 // OP_UPDATE
@@ -142,4 +145,5 @@ type MessageMessage struct {
 
 	FlagBits int32
 	Sections []MessageMessageSection
+	BodyDoc  bsoncore.Document
 }

--- a/wire_message.go
+++ b/wire_message.go
@@ -119,6 +119,7 @@ func parseMessageMessage(header MessageHeader, buf []byte) (Message, error) {
 		if kind == BodySectionKind {
 			if section.(*BodySection) != nil {
 				hasBodySection = true
+				msg.BodyDoc = section.(*BodySection).Body.BSON
 			}
 		}
 		sections = append(sections, section)

--- a/wire_reply.go
+++ b/wire_reply.go
@@ -1,5 +1,7 @@
 package mongonet
 
+import "go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+
 func (m *ReplyMessage) HasResponse() bool {
 	return false // because its a response
 }
@@ -65,6 +67,8 @@ func parseReplyMessage(header MessageHeader, buf []byte) (Message, error) {
 		rm.Docs = append(rm.Docs, doc)
 		loc += int(doc.Size)
 	}
-
+	if len(rm.Docs) > 0 {
+		rm.CommandDoc = bsoncore.Document(rm.Docs[0].BSON)
+	}
 	return rm, nil
 }


### PR DESCRIPTION
When drivers are connected to a cluster, they need to make sure they don’t route operations to nodes that are down. They handle this by:

1. Periodic background monitoring checks - This will be handled by our mongo.Client
2. Application error handling:
  - Drivers have some error handling code that marks a node as “down” if needed.
  - We will need to handle this part because we will be bypassing the driver’s operations layer
