### PR TITLE
Create request and response timing and errors metric hooks

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,8 @@ type ProxyConfig struct {
 	MongoUser          string
 	MongoPassword      string
 
-	InterceptorFactory ProxyInterceptorFactory
+	InterceptorFactory   ProxyInterceptorFactory
+	CollectorHookFactory MetricsHookFactory
 
 	AppName string
 
@@ -70,6 +71,7 @@ func NewProxyConfig(bindHost string, bindPort int, mongoUri, mongoHost string, m
 		mongoUser,
 		mongoPassword,
 		nil, // InterceptorFactory
+		nil, // CollectorHookFactory
 		appName,
 		traceConnPool,
 		connectionMode,

--- a/proxy.go
+++ b/proxy.go
@@ -592,7 +592,9 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		}
 
 		ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, resp)
-		responseDurationHook.StopTimer()
+		if ps.isMetricsEnabled {
+			responseDurationHook.StopTimer()
+		}
 
 		// Send message back to user
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sending back data to user from mongo conn %v", mongoConn.conn.ID())

--- a/proxy.go
+++ b/proxy.go
@@ -785,12 +785,12 @@ func (p *Proxy) CreateWorker(session *Session) (ServerWorker, error) {
 				return nil, err
 			}
 
-			requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "request")
+			requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingErrors", "type", "request")
 			if err != nil {
 				return nil, err
 			}
 
-			responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "response")
+			responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingErrors", "type", "response")
 			if err != nil {
 				return nil, err
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -775,22 +775,22 @@ func (p *Proxy) CreateWorker(session *Session) (ServerWorker, error) {
 		}
 
 		if ps.proxy.config.CollectorHookFactory != nil {
-			requestDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "request_total")
+			requestDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "request_total")
 			if err != nil {
 				return nil, err
 			}
 
-			responseDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "response_total")
+			responseDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "response_total")
 			if err != nil {
 				return nil, err
 			}
 
-			requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "request")
+			requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "request")
 			if err != nil {
 				return nil, err
 			}
 
-			responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "response")
+			responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("processingDuration", "type", "response")
 			if err != nil {
 				return nil, err
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -130,7 +130,22 @@ type ProxySession struct {
 
 	proxy       *Proxy
 	interceptor ProxyInterceptor
+	hooks       map[string]MetricsHook
 	mongoConn   *MongoConnectionWrapper
+}
+
+type MetricsHook interface {
+	StartTimer() error
+	StopTimer()
+	SetGauge(val float64) error
+	AddCounterGauge(val float64) error
+	SubGauge(val float64) error
+	IncCounterGauge() error
+	DecGauge() error
+}
+
+type MetricsHookFactory interface {
+	NewHook(metricName, labelName, labelValue string) (MetricsHook, error)
 }
 
 type ResponseInterceptor interface {
@@ -390,11 +405,34 @@ func wrapNetworkError(err error) error {
 }
 
 func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnectionWrapper, error) {
+	requestDurationHook, ok := ps.hooks["requestDurationHook"]
+	if !ok {
+		return nil, fmt.Errorf("could not access the request processing duration metric hook")
+	}
+	responseDurationHook, ok := ps.hooks["responseDurationHook"]
+	if !ok {
+		return nil, fmt.Errorf("could not access the response processing duration metric hook")
+	}
+	requestErrorsHook, ok := ps.hooks["requestErrorsHook"]
+	if !ok {
+		return nil, fmt.Errorf("could not access the request processing errors metric hook")
+	}
+	responseErrorsHook, ok := ps.hooks["responseErrorsHook"]
+	if !ok {
+		return nil, fmt.Errorf("could not access the response processing errors metric hook")
+	}
+
 	// reading message from client
+	err := requestDurationHook.StartTimer()
+	if err != nil {
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start request duration metric hook timer %v", err)
+	}
+
 	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client")
 	m, err := ReadMessage(ps.conn)
 	if err != nil {
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client fail %v", err)
+		requestErrorsHook.IncCounterGauge()
 		if err == io.EOF {
 			return mongoConn, err
 		}
@@ -407,6 +445,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		if ok {
 			rp2, err := getReadPrefFromOpMsg(mm, ps.proxy.logger, rp)
 			if err != nil {
+				requestErrorsHook.IncCounterGauge()
 				return mongoConn, err
 			}
 			if rp2 != nil {
@@ -422,13 +461,16 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		m, respInter, err = ps.interceptor.InterceptClientToMongo(m)
 		if err != nil {
 			if m == nil {
+				requestErrorsHook.IncCounterGauge()
 				return mongoConn, err
 			}
 			if !m.HasResponse() {
 				// we can't respond, so we just fail
+				requestErrorsHook.IncCounterGauge()
 				return mongoConn, err
 			}
 			if respondErr := ps.RespondWithError(m, err); respondErr != nil {
+				requestErrorsHook.IncCounterGauge()
 				return mongoConn, NewStackErrorf("couldn't send error response to client; original error: %v, error sending response: %v", err, respondErr)
 			}
 			return mongoConn, nil
@@ -441,15 +483,19 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 	if mongoConn == nil || !mongoConn.expirableConn.Alive() {
 		mongoConn, err = ps.getMongoConnection(rp)
 		if err != nil {
+			requestErrorsHook.IncCounterGauge()
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to get a new connection. err=%v", err)
 			return nil, NewStackErrorf("cannot get connection to mongo %v using connection mode=%v readpref=%v", err, ps.proxy.config.ConnectionMode, rp)
 		}
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got new connection %v using connection mode=%v readpref=%v", mongoConn.conn.ID(), ps.proxy.config.ConnectionMode, rp)
 	}
 
+	requestDurationHook.StopTimer()
+
 	// Send message to mongo
 	err = mongoConn.conn.WriteWireMessage(ps.proxy.Context, m.Serialize())
 	if err != nil {
+		requestErrorsHook.IncCounterGauge()
 		mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
 		return mongoConn, NewStackErrorf("error writing to mongo: %v", err)
 	}
@@ -467,13 +513,21 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		ret, err := mongoConn.conn.ReadWireMessage(ps.proxy.Context, nil)
 		if err != nil {
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading wire message mongo conn %v %v", mongoConn.conn.ID(), err)
+			responseErrorsHook.IncCounterGauge()
 			mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
 			return nil, NewStackErrorf("error reading wire message from mongo conn %v: %v", mongoConn.conn.ID(), err)
 		}
+
+		err = responseDurationHook.StartTimer()
+		if err != nil {
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start response duration metric hook timer %v", err)
+		}
+
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "read data from mongo conn %v", mongoConn.conn.ID())
 		resp, err := ReadMessageFromBytes(ret)
 		if err != nil {
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading message from bytes on mongo conn %v %v", mongoConn.conn.ID(), err)
+			responseErrorsHook.IncCounterGauge()
 			if err == io.EOF {
 				return nil, err
 			}
@@ -482,11 +536,13 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		switch mm := resp.(type) {
 		case *MessageMessage:
 			if err := extractError(mm.BodyDoc); err != nil {
+				responseErrorsHook.IncCounterGauge()
 				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
 				mongoConn.ep.ProcessError(err, mongoConn.conn)
 			}
 		case *ReplyMessage:
 			if err := extractError(mm.CommandDoc); err != nil {
+				responseErrorsHook.IncCounterGauge()
 				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
 				mongoConn.ep.ProcessError(err, mongoConn.conn)
 			}
@@ -494,14 +550,19 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		if respInter != nil {
 			resp, err = respInter.InterceptMongoToClient(resp)
 			if err != nil {
+				responseErrorsHook.IncCounterGauge()
 				return nil, NewStackErrorf("error intercepting message %v", err)
 			}
 		}
+
 		ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, resp)
+		responseDurationHook.StopTimer()
+
 		// Send message back to user
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sending back data to user from mongo conn %v", mongoConn.conn.ID())
 		err = SendMessage(resp, ps.conn)
 		if err != nil {
+			responseErrorsHook.IncCounterGauge()
 			mongoConn.bad = true
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got error sending response to client from conn %v. err=%v", mongoConn.conn.ID(), err)
 			return nil, NewStackErrorf("got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
@@ -526,6 +587,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 				return nil, nil
 			}
 		default:
+			responseErrorsHook.IncCounterGauge()
 			return nil, NewStackErrorf("bad response type from server %T", r)
 		}
 	}
@@ -663,12 +725,38 @@ func (p *Proxy) GetPoolCleared() int64 {
 func (p *Proxy) CreateWorker(session *Session) (ServerWorker, error) {
 	var err error
 
-	ps := &ProxySession{session, p, nil, nil}
+	ps := &ProxySession{session, p, nil, nil, nil}
 	if p.config.InterceptorFactory != nil {
 		ps.interceptor, err = ps.proxy.config.InterceptorFactory.NewInterceptor(ps)
 		if err != nil {
 			return nil, err
 		}
+
+		requestDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "request_total")
+		if err != nil {
+			return nil, err
+		}
+
+		responseDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "response_total")
+		if err != nil {
+			return nil, err
+		}
+
+		requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "request")
+		if err != nil {
+			return nil, err
+		}
+
+		responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "response")
+		if err != nil {
+			return nil, err
+		}
+
+		ps.hooks = make(map[string]MetricsHook)
+		ps.hooks["requestDurationHook"] = requestDurationHook
+		ps.hooks["responseDurationHook"] = responseDurationHook
+		ps.hooks["requestErrorsHook"] = requestErrorsHook
+		ps.hooks["responseErrorsHook"] = responseErrorsHook
 
 		session.conn = CheckedConn{session.conn.(net.Conn), ps.interceptor}
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -128,10 +128,11 @@ func (m *MongoConnectionWrapper) Close(ps *ProxySession) {
 type ProxySession struct {
 	*Session
 
-	proxy       *Proxy
-	interceptor ProxyInterceptor
-	hooks       map[string]MetricsHook
-	mongoConn   *MongoConnectionWrapper
+	proxy            *Proxy
+	interceptor      ProxyInterceptor
+	hooks            map[string]MetricsHook
+	mongoConn        *MongoConnectionWrapper
+	isMetricsEnabled bool
 }
 
 type MetricsHook interface {
@@ -405,34 +406,43 @@ func wrapNetworkError(err error) error {
 }
 
 func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnectionWrapper, error) {
-	requestDurationHook, ok := ps.hooks["requestDurationHook"]
-	if !ok {
-		return nil, fmt.Errorf("could not access the request processing duration metric hook")
-	}
-	responseDurationHook, ok := ps.hooks["responseDurationHook"]
-	if !ok {
-		return nil, fmt.Errorf("could not access the response processing duration metric hook")
-	}
-	requestErrorsHook, ok := ps.hooks["requestErrorsHook"]
-	if !ok {
-		return nil, fmt.Errorf("could not access the request processing errors metric hook")
-	}
-	responseErrorsHook, ok := ps.hooks["responseErrorsHook"]
-	if !ok {
-		return nil, fmt.Errorf("could not access the response processing errors metric hook")
+	var requestDurationHook, responseDurationHook, requestErrorsHook, responseErrorsHook MetricsHook
+
+	if ps.isMetricsEnabled {
+		var ok bool
+		requestDurationHook, ok = ps.hooks["requestDurationHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the request processing duration metric hook")
+		}
+		responseDurationHook, ok = ps.hooks["responseDurationHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the response processing duration metric hook")
+		}
+		requestErrorsHook, ok = ps.hooks["requestErrorsHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the request processing errors metric hook")
+		}
+		responseErrorsHook, ok = ps.hooks["responseErrorsHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the response processing errors metric hook")
+		}
 	}
 
 	// reading message from client
-	err := requestDurationHook.StartTimer()
-	if err != nil {
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start request duration metric hook timer %v", err)
+	if ps.isMetricsEnabled {
+		err := requestDurationHook.StartTimer()
+		if err != nil {
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start request duration metric hook timer %v", err)
+		}
 	}
 
 	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client")
 	m, err := ReadMessage(ps.conn)
 	if err != nil {
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client fail %v", err)
-		requestErrorsHook.IncCounterGauge()
+		if ps.isMetricsEnabled {
+			requestErrorsHook.IncCounterGauge()
+		}
 		if err == io.EOF {
 			return mongoConn, err
 		}
@@ -445,7 +455,9 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		if ok {
 			rp2, err := getReadPrefFromOpMsg(mm, ps.proxy.logger, rp)
 			if err != nil {
-				requestErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					requestErrorsHook.IncCounterGauge()
+				}
 				return mongoConn, err
 			}
 			if rp2 != nil {
@@ -461,16 +473,22 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		m, respInter, err = ps.interceptor.InterceptClientToMongo(m)
 		if err != nil {
 			if m == nil {
-				requestErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					requestErrorsHook.IncCounterGauge()
+				}
 				return mongoConn, err
 			}
 			if !m.HasResponse() {
 				// we can't respond, so we just fail
-				requestErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					requestErrorsHook.IncCounterGauge()
+				}
 				return mongoConn, err
 			}
 			if respondErr := ps.RespondWithError(m, err); respondErr != nil {
-				requestErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					requestErrorsHook.IncCounterGauge()
+				}
 				return mongoConn, NewStackErrorf("couldn't send error response to client; original error: %v, error sending response: %v", err, respondErr)
 			}
 			return mongoConn, nil
@@ -483,19 +501,25 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 	if mongoConn == nil || !mongoConn.expirableConn.Alive() {
 		mongoConn, err = ps.getMongoConnection(rp)
 		if err != nil {
-			requestErrorsHook.IncCounterGauge()
+			if ps.isMetricsEnabled {
+				requestErrorsHook.IncCounterGauge()
+			}
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to get a new connection. err=%v", err)
 			return nil, NewStackErrorf("cannot get connection to mongo %v using connection mode=%v readpref=%v", err, ps.proxy.config.ConnectionMode, rp)
 		}
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got new connection %v using connection mode=%v readpref=%v", mongoConn.conn.ID(), ps.proxy.config.ConnectionMode, rp)
 	}
 
-	requestDurationHook.StopTimer()
+	if ps.isMetricsEnabled {
+		requestDurationHook.StopTimer()
+	}
 
 	// Send message to mongo
 	err = mongoConn.conn.WriteWireMessage(ps.proxy.Context, m.Serialize())
 	if err != nil {
-		requestErrorsHook.IncCounterGauge()
+		if ps.isMetricsEnabled {
+			requestErrorsHook.IncCounterGauge()
+		}
 		mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
 		return mongoConn, NewStackErrorf("error writing to mongo: %v", err)
 	}
@@ -513,21 +537,27 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		ret, err := mongoConn.conn.ReadWireMessage(ps.proxy.Context, nil)
 		if err != nil {
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading wire message mongo conn %v %v", mongoConn.conn.ID(), err)
-			responseErrorsHook.IncCounterGauge()
+			if ps.isMetricsEnabled {
+				responseErrorsHook.IncCounterGauge()
+			}
 			mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
 			return nil, NewStackErrorf("error reading wire message from mongo conn %v: %v", mongoConn.conn.ID(), err)
 		}
 
-		err = responseDurationHook.StartTimer()
-		if err != nil {
-			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start response duration metric hook timer %v", err)
+		if ps.isMetricsEnabled {
+			err = responseDurationHook.StartTimer()
+			if err != nil {
+				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to start response duration metric hook timer %v", err)
+			}
 		}
 
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "read data from mongo conn %v", mongoConn.conn.ID())
 		resp, err := ReadMessageFromBytes(ret)
 		if err != nil {
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading message from bytes on mongo conn %v %v", mongoConn.conn.ID(), err)
-			responseErrorsHook.IncCounterGauge()
+			if ps.isMetricsEnabled {
+				responseErrorsHook.IncCounterGauge()
+			}
 			if err == io.EOF {
 				return nil, err
 			}
@@ -536,13 +566,17 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		switch mm := resp.(type) {
 		case *MessageMessage:
 			if err := extractError(mm.BodyDoc); err != nil {
-				responseErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					responseErrorsHook.IncCounterGauge()
+				}
 				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
 				mongoConn.ep.ProcessError(err, mongoConn.conn)
 			}
 		case *ReplyMessage:
 			if err := extractError(mm.CommandDoc); err != nil {
-				responseErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					responseErrorsHook.IncCounterGauge()
+				}
 				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
 				mongoConn.ep.ProcessError(err, mongoConn.conn)
 			}
@@ -550,7 +584,9 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		if respInter != nil {
 			resp, err = respInter.InterceptMongoToClient(resp)
 			if err != nil {
-				responseErrorsHook.IncCounterGauge()
+				if ps.isMetricsEnabled {
+					responseErrorsHook.IncCounterGauge()
+				}
 				return nil, NewStackErrorf("error intercepting message %v", err)
 			}
 		}
@@ -562,7 +598,9 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sending back data to user from mongo conn %v", mongoConn.conn.ID())
 		err = SendMessage(resp, ps.conn)
 		if err != nil {
-			responseErrorsHook.IncCounterGauge()
+			if ps.isMetricsEnabled {
+				responseErrorsHook.IncCounterGauge()
+			}
 			mongoConn.bad = true
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got error sending response to client from conn %v. err=%v", mongoConn.conn.ID(), err)
 			return nil, NewStackErrorf("got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
@@ -587,7 +625,9 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 				return nil, nil
 			}
 		default:
-			responseErrorsHook.IncCounterGauge()
+			if ps.isMetricsEnabled {
+				responseErrorsHook.IncCounterGauge()
+			}
 			return nil, NewStackErrorf("bad response type from server %T", r)
 		}
 	}
@@ -725,38 +765,42 @@ func (p *Proxy) GetPoolCleared() int64 {
 func (p *Proxy) CreateWorker(session *Session) (ServerWorker, error) {
 	var err error
 
-	ps := &ProxySession{session, p, nil, nil, nil}
+	ps := &ProxySession{session, p, nil, nil, nil, false}
 	if p.config.InterceptorFactory != nil {
 		ps.interceptor, err = ps.proxy.config.InterceptorFactory.NewInterceptor(ps)
 		if err != nil {
 			return nil, err
 		}
 
-		requestDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "request_total")
-		if err != nil {
-			return nil, err
-		}
+		if ps.proxy.config.CollectorHookFactory != nil {
+			requestDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "request_total")
+			if err != nil {
+				return nil, err
+			}
 
-		responseDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "response_total")
-		if err != nil {
-			return nil, err
-		}
+			responseDurationHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_duration_seconds", "type", "response_total")
+			if err != nil {
+				return nil, err
+			}
 
-		requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "request")
-		if err != nil {
-			return nil, err
-		}
+			requestErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "request")
+			if err != nil {
+				return nil, err
+			}
 
-		responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "response")
-		if err != nil {
-			return nil, err
-		}
+			responseErrorsHook, err := ps.proxy.config.CollectorHookFactory.NewHook("mtmproxy_processing_errors_total", "type", "response")
+			if err != nil {
+				return nil, err
+			}
 
-		ps.hooks = make(map[string]MetricsHook)
-		ps.hooks["requestDurationHook"] = requestDurationHook
-		ps.hooks["responseDurationHook"] = responseDurationHook
-		ps.hooks["requestErrorsHook"] = requestErrorsHook
-		ps.hooks["responseErrorsHook"] = responseErrorsHook
+			ps.hooks = make(map[string]MetricsHook)
+			ps.hooks["requestDurationHook"] = requestDurationHook
+			ps.hooks["responseDurationHook"] = responseDurationHook
+			ps.hooks["requestErrorsHook"] = requestErrorsHook
+			ps.hooks["responseErrorsHook"] = responseErrorsHook
+
+			ps.isMetricsEnabled = true
+		}
 
 		session.conn = CheckedConn{session.conn.(net.Conn), ps.interceptor}
 	}


### PR DESCRIPTION
This PR adds hooks to measure request and response time and track the number of errors encountered during this process. The hook is designed to be analogous to `ProxyInterceptor` and `ProxyInterceptorFactory`, with `MetricsHook` and `MetricsHookFactory`, respectively. Each `ProxyConfig` now contains a `MetricsHookFactory` field called `CollectorHookFactory`. A non-nil type that implements `CollectorHookFactory` implements the `NewHook()` method, which enables it to create new `MetricsHook`s. Meanwhile, the `ProxySession` type now includes two additional fields: `hooks`, which is a map of `MetricsHook`s, and `isMetricsEnabled`, a bool. When `CreateWorker` is called to generate a new `ProxySession`, `hooks` is populated with `MetricsHook`s generated from the `ProxyConfig`'s `CollectorHookFactory` field (provided that it is non-nil). At the moment, the `MetricsHook`s included are all the ones that are needed for the metrics being tracked, but more can be easily added as necessary. Meanwhile, `isMetricsEnabled` is set to true only if the `CollectorHookFactory` field was non-nil. If it was `nil`, then none of the hooks can be created, and `isMetricsEnabled` is set to false so that any hook updates are ignored. This should only occur during `mongonet`-only tests.

Each type implementing a `MetricHook` implements `StartTimer()`, `StopTimer()`, `SetGauge()`, `AddCounterGauge()`, `IncCounterGauge()`, `DecGauge()`, and `SubGauge()`. The type could wrap (for example) a Prometheus metric, and by implementing these methods, it will be able to perform any basic action on its underlying metric. Any metric hook can be accessed from a `ProxySession` via the hooks map, provided that the programmer uses the same string key to access the metric as they did to insert it into the map in `CreateWorker()`. Lastly, each hook is utilized wherever necessary, using the appropriate method to modify the underlying metric provided that the hook was initialized in the first place (hence all of the `isMetricsEnabled` checks).
