### PR TITLE
Remote Connections API

### DIFF
--- a/inttests/proxy_remoteconns_test.go
+++ b/inttests/proxy_remoteconns_test.go
@@ -1,0 +1,30 @@
+package inttests
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongonet/util"
+)
+
+func TestProxyMongosModeConnectionPerformanceRemoteConns(t *testing.T) {
+	goals := []ConnectionPerformanceTestGoal{
+		{
+			Workers:      5,
+			AvgLatencyMs: 50,
+			MaxLatencyMs: 200,
+		},
+		{
+			Workers:      20,
+			AvgLatencyMs: 100,
+			MaxLatencyMs: 500,
+		},
+		{
+			Workers:      60,
+			AvgLatencyMs: 200,
+			MaxLatencyMs: 1500,
+		},
+	}
+	for _, goal := range goals {
+		RunIntTest(util.Cluster, 0, goal.Workers, goal.AvgLatencyMs, goal.MaxLatencyMs, t, runProxyConnectionPerformanceRemoteConns)
+	}
+}

--- a/inttests/remoteConns.go
+++ b/inttests/remoteConns.go
@@ -1,0 +1,133 @@
+package inttests
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/mongodb/mongonet"
+	"github.com/mongodb/mongonet/util"
+	"github.com/mongodb/slogger/v2/slogger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const (
+	LocalDbName        = "testlocal"
+	RemoteConnCollName = "test"
+)
+
+func RunProxyConnectionPerformanceRemoteConns(iterations, mongoPort, proxyPort int, hostname string, logger *slogger.Logger, mode util.MongoConnectionMode, goals []ConnectionPerformanceTestGoal,
+	mongoClientFactory util.ClientFactoryFunc,
+	proxyClientFactory util.ClientFactoryFunc,
+) error {
+	for _, goal := range goals {
+		if err := runProxyConnectionPerformanceRemoteConns(iterations, mongoPort, proxyPort, hostname, logger, goal.Workers, goal.AvgLatencyMs, goal.MaxLatencyMs, mode, mongoClientFactory, proxyClientFactory); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findOne(logger *slogger.Logger, coll *mongo.Collection, goctx context.Context) error {
+	rand.Seed(time.Now().UnixNano())
+	doc := bson.D{}
+	res := coll.FindOne(goctx, bson.D{})
+	if res.Err() != nil {
+		return res.Err()
+	}
+	if err := res.Decode(&doc); err != nil {
+		return err
+	}
+	ix := mongonet.BSONIndexOf(doc, "a")
+	val, _, err := mongonet.GetAsInt(doc[ix])
+	if err != nil {
+		return err
+	}
+	if coll.Database().Name() == util.RemoteDbNameForTests {
+		if val != 2 {
+			return fmt.Errorf("got unexpected value=%v", val)
+		}
+	} else {
+		if val != 1 {
+			return fmt.Errorf("got unexpected value=%v", val)
+		}
+	}
+
+	return nil
+}
+
+func runRemoteConns(logger *slogger.Logger, client *mongo.Client, workerNum int, ctx context.Context) (time.Duration, bool, error) {
+	rand.Seed(time.Now().UnixNano())
+	start := time.Now()
+
+	localColl := client.Database(LocalDbName).Collection(RemoteConnCollName)
+	remoteColl := client.Database(util.RemoteDbNameForTests).Collection(RemoteConnCollName)
+
+	coll := localColl
+	if workerNum%2 == 0 {
+		coll = remoteColl
+	}
+
+	if err := findOne(logger, coll, ctx); err != nil {
+		return 0, false, err
+	}
+
+	elapsed := time.Since(start)
+	logger.Logf(slogger.DEBUG, "worker-%v finished after %v", workerNum, elapsed)
+	return elapsed, true, nil
+}
+
+func runProxyConnectionPerformanceRemoteConns(iterations, mongoPort, proxyPort int, hostname string, logger *slogger.Logger, workers int, targetAvgLatencyMs, targetMaxLatencyMs int64, mode util.MongoConnectionMode,
+	mongoClientFactory util.ClientFactoryFunc,
+	proxyClientFactory util.ClientFactoryFunc,
+) error {
+	preSetupFunc := func(logger *slogger.Logger, client *mongo.Client, ctx context.Context) error {
+		client2, err := mongoClientFactory(hostname, 40000, util.Cluster, false, "presetup", ctx)
+		if err != nil {
+			return err
+		}
+		defer client2.Disconnect(ctx)
+		if err := util.DisableFailPoint(client2, ctx); err != nil {
+			return err
+		}
+		return util.DisableFailPoint(client, ctx)
+	}
+	setupFunc := func(logger *slogger.Logger, client *mongo.Client, ctx context.Context) error {
+		localColl := client.Database(LocalDbName).Collection(RemoteConnCollName)
+		client2, err := mongoClientFactory(hostname, 40000, util.Cluster, false, "presetup", ctx)
+		if err != nil {
+			return err
+		}
+		defer client2.Disconnect(ctx)
+		remoteColl := client2.Database(util.RemoteDbNameForTests).Collection(RemoteConnCollName)
+		if _, err := localColl.InsertOne(ctx, bson.D{{"a", 1}}); err != nil {
+			return err
+		}
+		if _, err := remoteColl.InsertOne(ctx, bson.D{{"a", 2}}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	testFunc := func(logger *slogger.Logger, client *mongo.Client, workerNum, iteration int, ctx context.Context) (elapsed time.Duration, success bool, err error) {
+		return runRemoteConns(logger, client, workerNum, ctx)
+	}
+
+	cleanupFunc := func(logger *slogger.Logger, client *mongo.Client, ctx context.Context) error {
+		return nil
+	}
+	results, failedCount, maxLatencyMs, avgLatencyMs, percentiles, err := DoConcurrencyTestRun(logger,
+		hostname, mongoPort, proxyPort, mode,
+		mongoClientFactory,
+		proxyClientFactory,
+		iterations, workers,
+		preSetupFunc,
+		setupFunc,
+		testFunc,
+		cleanupFunc,
+	)
+
+	return analyzeResults(err, workers, failedCount, avgLatencyMs, targetAvgLatencyMs, maxLatencyMs, targetMaxLatencyMs, results, percentiles, logger)
+}

--- a/inttests/remoteConns.go
+++ b/inttests/remoteConns.go
@@ -65,6 +65,7 @@ func runRemoteConns(logger *slogger.Logger, client *mongo.Client, workerNum int,
 	localColl := client.Database(LocalDbName).Collection(RemoteConnCollName)
 	remoteColl := client.Database(util.RemoteDbNameForTests).Collection(RemoteConnCollName)
 
+	// we'd like to simulate a workload in which 50% of the connections are local and 50% are remote
 	coll := localColl
 	if workerNum%2 == 0 {
 		coll = remoteColl

--- a/inttests/run_integration_tests_mongos_mode.sh
+++ b/inttests/run_integration_tests_mongos_mode.sh
@@ -5,21 +5,28 @@ echo ### RUNNING INTEGRATION TESTS
 # If you do no set MONGO_DIR on the command line it will default to the value below
 MONGO_DIR=${MONGO_DIR:-"/opt/mongo/64/3.4.0/bin"}
 export MONGO_PORT=30000 # base port
-#HOSTNAME=`hostname -f`
 HOSTNAME="localhost"
 
 pkill mongod
 sleep 5
 
 rm -rf dbpath || true
-mkdir -p dbpath/1 dbpath/2 dbpath/3 || true
+mkdir -p dbpath/1 dbpath/2 dbpath/3 dbpath/4 dbpath/5 dbpath/6 || true
 $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath/1 --logpath `pwd`/dbpath/1/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest
 $MONGO_DIR/mongod --port $((MONGO_PORT+1)) --dbpath `pwd`/dbpath/2 --logpath `pwd`/dbpath/2/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest
 $MONGO_DIR/mongod --port $((MONGO_PORT+2)) --dbpath `pwd`/dbpath/3 --logpath `pwd`/dbpath/3/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest
 
 $MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest', 'protocolVersion': 1, 'writeConcernMajorityJournalDefault': false, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
 
-sleep 10 # let replica set reach steady state
+MONGO_PORT=40000
+$MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath/4 --logpath `pwd`/dbpath/4/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
+$MONGO_DIR/mongod --port $((MONGO_PORT+1)) --dbpath `pwd`/dbpath/5 --logpath `pwd`/dbpath/5/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
+$MONGO_DIR/mongod --port $((MONGO_PORT+2)) --dbpath `pwd`/dbpath/6 --logpath `pwd`/dbpath/6/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
+
+$MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest2', 'protocolVersion': 1, 'writeConcernMajorityJournalDefault': false, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
+
+
+sleep 10 # let replica sets reach steady state
 
 go test -test.v -run TestProxyMongosMode
 

--- a/inttests/run_integration_tests_mongos_mode.sh
+++ b/inttests/run_integration_tests_mongos_mode.sh
@@ -16,14 +16,14 @@ $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath/1 --logpath `pwd`/dbp
 $MONGO_DIR/mongod --port $((MONGO_PORT+1)) --dbpath `pwd`/dbpath/2 --logpath `pwd`/dbpath/2/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest
 $MONGO_DIR/mongod --port $((MONGO_PORT+2)) --dbpath `pwd`/dbpath/3 --logpath `pwd`/dbpath/3/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest
 
-$MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest', 'protocolVersion': 1, 'writeConcernMajorityJournalDefault': false, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
+$MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest', 'protocolVersion': 1, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
 
 MONGO_PORT=40000
 $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath/4 --logpath `pwd`/dbpath/4/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
 $MONGO_DIR/mongod --port $((MONGO_PORT+1)) --dbpath `pwd`/dbpath/5 --logpath `pwd`/dbpath/5/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
 $MONGO_DIR/mongod --port $((MONGO_PORT+2)) --dbpath `pwd`/dbpath/6 --logpath `pwd`/dbpath/6/mongod.log --fork --setParameter enableTestCommands=1 --replSet proxytest2
 
-$MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest2', 'protocolVersion': 1, 'writeConcernMajorityJournalDefault': false, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
+$MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest2', 'protocolVersion': 1, 'members': [{_id:0, host:'$HOSTNAME:$MONGO_PORT'},{_id:1, host:'$HOSTNAME:$((MONGO_PORT+1))',priority:0},{_id:2, host:'$HOSTNAME:$((MONGO_PORT+2))',priority:0}]})"
 
 
 sleep 10 # let replica sets reach steady state

--- a/inttests/testrunner.go
+++ b/inttests/testrunner.go
@@ -190,7 +190,7 @@ func RunIntTest(mode util.MongoConnectionMode, maxPoolSize, workers int, targetA
 	}
 
 	if mode == util.Cluster {
-		if err := proxy.AddRemoteConnection("proxytest2", "mongodb://localhost:40000,localhost:40001,localhost:40002", "testproxy", false, ServerSelectionTimeoutSecForTests, maxPoolSize, nil); err != nil {
+		if err := proxy.AddRemoteConnection("proxytest2", "mongodb://localhost:40000,localhost:40001,localhost:40002", "testproxy", false, ServerSelectionTimeoutSecForTests, maxPoolSize, DefaultMaxPoolIdleTimeSec, DefaultConnectionPoolHeartbeatIntervalMs, nil); err != nil {
 			t.Fatal(err)
 		}
 		defer proxy.ClearRemoteConnection("proxytest2", 10)

--- a/inttests/testrunner.go
+++ b/inttests/testrunner.go
@@ -189,6 +189,12 @@ func RunIntTest(mode util.MongoConnectionMode, maxPoolSize, workers int, targetA
 		panic("failed to call OnSSLConfig")
 	}
 
+	if mode == util.Cluster {
+		if err := proxy.AddRemoteConnection("proxytest2", "mongodb://localhost:40000,localhost:40001,localhost:40002", "testproxy", false, ServerSelectionTimeoutSecForTests, maxPoolSize, nil); err != nil {
+			t.Fatal(err)
+		}
+		defer proxy.ClearRemoteConnection("proxytest2", 10)
+	}
 	go proxy.Run()
 
 	if err := testFunc(Iterations, mongoPort, proxyPort, hostToUse, proxy.NewLogger("tester"), workers, targetAvgLatencyMs, targetMaxLatencyMs, mode, util.GetTestClient, util.GetTestClient); err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -1,31 +1,24 @@
 package mongonet
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"errors"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
 	"reflect"
-	"runtime/pprof"
-	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
 
 	"github.com/mongodb/mongonet/util"
 	"github.com/mongodb/slogger/v2/slogger"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
@@ -41,259 +34,14 @@ type Proxy struct {
 	Context            context.Context
 	connectionsCreated *int64
 	poolCleared        *int64
+
+	// using a sync.Map instead of a map paired with mutex because sync.Map is optimized for cases in which the access pattern is predominant by reads
+	remoteConnections sync.Map
 }
 
-func (ps *ProxySession) logTrace(logger *slogger.Logger, trace bool, format string, args ...interface{}) {
-	if trace {
-		msg := fmt.Sprintf(fmt.Sprintf("client: %v - %s", ps.RemoteAddr(), format), args...)
-		logger.Logf(slogger.DEBUG, msg)
-	}
-}
-
-func (ps *ProxySession) logMessageTrace(logger *slogger.Logger, trace bool, m Message) {
-	if trace {
-		var doc bson.D
-		var msg string
-		var err error
-		switch mm := m.(type) {
-		case *MessageMessage:
-			for _, section := range mm.Sections {
-				if bs, ok := section.(*BodySection); ok {
-					doc, err = bs.Body.ToBSOND()
-					if err != nil {
-						logger.Logf(slogger.WARN, "failed to convert body to Bson.D. err=%v", err)
-						return
-					}
-					break
-				}
-			}
-			msg = fmt.Sprintf("got OP_MSG %v", doc)
-		case *QueryMessage:
-			doc, err = mm.Query.ToBSOND()
-			if err != nil {
-				logger.Logf(slogger.WARN, "failed to convert query to Bson.D. err=%v", err)
-				return
-			}
-			msg = fmt.Sprintf("got OP_QUERY %v", doc)
-		case *ReplyMessage:
-			doc, err = mm.Docs[0].ToBSOND()
-			if err != nil {
-				logger.Logf(slogger.WARN, "failed to convert reply doc to Bson.D. err=%v", err)
-				return
-			}
-			msg = fmt.Sprintf("got OP_REPLY %v", doc)
-		default:
-			// not bothering about printing other message types
-			msg = fmt.Sprintf("got another type %T", mm)
-		}
-		msg = fmt.Sprintf("client: %v - %s", ps.RemoteAddr(), msg)
-		logger.Logf(slogger.DEBUG, msg)
-	}
-}
-
-// MongoConnectionWrapper is used to wrap the driver connection so we can explicitly expire (close out) connections on certain occasions that aren't being picked up by the driver
-type MongoConnectionWrapper struct {
-	conn          driver.Connection
-	ep            driver.ErrorProcessor
-	expirableConn driver.Expirable
-	bad           bool
-	logger        *slogger.Logger
-	trace         bool
-}
-
-func (m *MongoConnectionWrapper) Close(ps *ProxySession) {
-	if m.conn == nil {
-		m.logger.Logf(slogger.WARN, "attempt to close a nil mongo connection. noop")
-		return
-	}
-	id := m.conn.ID()
-	if m.bad {
-		if m.expirableConn.Alive() {
-			ps.logTrace(m.logger, m.trace, "closing underlying bad mongo connection %v", id)
-			if err := m.expirableConn.Expire(); err != nil {
-				ps.logTrace(m.logger, m.trace, "failed to expire connection. %v", err)
-			}
-		} else {
-			ps.logTrace(m.logger, m.trace, "bad mongo connection is nil!")
-		}
-	}
-	ps.logTrace(m.logger, m.trace, "closing mongo connection %v", id)
-	if m.expirableConn.Alive() {
-		if err := m.conn.Close(); err != nil {
-			ps.logTrace(m.logger, m.trace, "failed to close mongo connection %v: %v", id, err)
-		}
-	}
-}
-
-type ProxySession struct {
-	*Session
-
-	proxy            *Proxy
-	interceptor      ProxyInterceptor
-	hooks            map[string]MetricsHook
-	mongoConn        *MongoConnectionWrapper
-	isMetricsEnabled bool
-}
-
-type MetricsHook interface {
-	StartTimer() error
-	StopTimer()
-	SetGauge(val float64) error
-	AddCounterGauge(val float64) error
-	SubGauge(val float64) error
-	IncCounterGauge() error
-	DecGauge() error
-}
-
-type MetricsHookFactory interface {
-	NewHook(metricName, labelName, labelValue string) (MetricsHook, error)
-}
-
-type ResponseInterceptor interface {
-	InterceptMongoToClient(m Message) (Message, error)
-}
-
-type ProxyInterceptor interface {
-	InterceptClientToMongo(m Message) (Message, ResponseInterceptor, error)
-	Close()
-	TrackRequest(MessageHeader)
-	TrackResponse(MessageHeader)
-	CheckConnection() error
-	CheckConnectionInterval() time.Duration
-}
-
-type ProxyInterceptorFactory interface {
-	// This has to be thread safe, will be called from many clients
-	NewInterceptor(ps *ProxySession) (ProxyInterceptor, error)
-}
-
-// -----
-
-func (ps *ProxySession) RemoteAddr() net.Addr {
-	return ps.remoteAddr
-}
-
-func (ps *ProxySession) GetLogger() *slogger.Logger {
-	return ps.logger
-}
-
-func (ps *ProxySession) ServerPort() int {
-	return ps.proxy.config.BindPort
-}
-
-func (ps *ProxySession) Stats() bson.D {
-	return bson.D{
-		{"connectionPool", bson.D{
-			{"totalCreated", ps.proxy.GetConnectionsCreated()},
-		},
-		},
-	}
-}
-
-func (ps *ProxySession) DoLoopTemp() {
-	defer logPanic(ps.logger)
-	var err error
-	for {
-		ps.mongoConn, err = ps.doLoop(ps.mongoConn)
-		if err != nil {
-			if ps.mongoConn != nil {
-				ps.mongoConn.Close(ps)
-			}
-			if err != io.EOF {
-				ps.logger.Logf(slogger.WARN, "error doing loop: %v", err)
-			}
-			return
-		}
-	}
-}
-
-func (ps *ProxySession) respondWithError(clientMessage Message, err error) error {
-	ps.logger.Logf(slogger.INFO, "respondWithError %v", err)
-
-	var errBSON bson.D
-	if err == nil {
-		errBSON = bson.D{{"ok", 1}}
-	} else if mongoErr, ok := err.(MongoError); ok {
-		errBSON = mongoErr.ToBSON()
-	} else {
-		errBSON = bson.D{{"ok", 0}, {"errmsg", err.Error()}}
-	}
-
-	doc, myErr := SimpleBSONConvert(errBSON)
-	if myErr != nil {
-		return myErr
-	}
-
-	switch clientMessage.Header().OpCode {
-	case OP_QUERY, OP_GET_MORE:
-		rm := &ReplyMessage{
-			MessageHeader{
-				0,
-				17, // TODO
-				clientMessage.Header().RequestID,
-				OP_REPLY},
-
-			// We should not set the error bit because we are
-			// responding with errmsg instead of $err
-			0, // flags - error bit
-
-			0, // cursor id
-			0, // StartingFrom
-			1, // NumberReturned
-			[]SimpleBSON{doc},
-			bsoncore.Document(doc.BSON),
-		}
-		return SendMessage(rm, ps.conn)
-
-	case OP_COMMAND:
-		rm := &CommandReplyMessage{
-			MessageHeader{
-				0,
-				17, // TODO
-				clientMessage.Header().RequestID,
-				OP_COMMAND_REPLY},
-			doc,
-			SimpleBSONEmpty(),
-			[]SimpleBSON{},
-		}
-		return SendMessage(rm, ps.conn)
-
-	case OP_MSG:
-		rm := &MessageMessage{
-			MessageHeader{
-				0,
-				17, // TODO
-				clientMessage.Header().RequestID,
-				OP_MSG},
-			0,
-			[]MessageMessageSection{
-				&BodySection{
-					doc,
-				},
-			},
-			bsoncore.Document(doc.BSON),
-		}
-		return SendMessage(rm, ps.conn)
-
-	default:
-		panic(fmt.Sprintf("unsupported opcode %v", clientMessage.Header().OpCode))
-	}
-}
-
-func (ps *ProxySession) Close() {
-	if ps.interceptor != nil {
-		ps.interceptor.Close()
-	}
-}
-
-func logPanic(logger *slogger.Logger) {
-	if r := recover(); r != nil {
-		var stacktraces bytes.Buffer
-		pprof.Lookup("goroutine").WriteTo(&stacktraces, 2)
-		logger.Logf(slogger.ERROR, "Recovering from mongonet panic. error is: %v \n stack traces: %v", r, stacktraces.String())
-		logger.Flush()
-		panic(r)
-	}
+type RemoteConnection struct {
+	client   *mongo.Client
+	topology *topology.Topology
 }
 
 // https://jira.mongodb.org/browse/GODRIVER-1760 will add the ability to create a topology.Topology from ClientOptions
@@ -315,381 +63,12 @@ https://docs.mongodb.com/manual/core/read-preference-staleness/
 */
 const MinMaxStalenessVal int32 = 90
 
-func getReadPrefFromOpMsg(mm *MessageMessage, logger *slogger.Logger, defaultRp *readpref.ReadPref) (rp *readpref.ReadPref, err error) {
-	rpVal, err2 := mm.BodyDoc.LookupErr("$readPreference")
-	if err2 != nil {
-		if err2 == bsoncore.ErrElementNotFound {
-			return defaultRp, nil
-		}
-		return nil, fmt.Errorf("got an error looking up $readPreference: %v", err)
-	}
-	rpDoc, ok := rpVal.DocumentOK()
-	if !ok {
-		return nil, fmt.Errorf("$readPreference isn't a document")
-	}
-	opts := make([]readpref.Option, 0, 1)
-	if maxStalenessVal, err := rpDoc.LookupErr("maxStalenessSeconds"); err == nil {
-		if maxStalenessSec, ok := maxStalenessVal.AsInt32OK(); ok && maxStalenessSec >= MinMaxStalenessVal {
-			opts = append(opts, readpref.WithMaxStaleness(time.Duration(maxStalenessSec)*time.Second))
-		} else {
-			return nil, fmt.Errorf("maxStalenessSeconds %v is invalid", maxStalenessVal)
-		}
-	}
-	if modeVal, err2 := rpDoc.LookupErr("mode"); err2 == nil {
-		modeStr, ok := modeVal.StringValueOK()
-		if !ok {
-			return nil, fmt.Errorf("mode %v isn't a string", modeVal)
-		}
-		switch strings.ToLower(modeStr) {
-		case "primarypreferred":
-			return readpref.PrimaryPreferred(opts...), nil
-		case "secondary":
-			return readpref.Secondary(opts...), nil
-		case "secondarypreferred":
-			return readpref.SecondaryPreferred(opts...), nil
-		case "nearest":
-			return readpref.Nearest(opts...), nil
-		case "primary":
-			return defaultRp, nil
-		default:
-			return nil, fmt.Errorf("got unsupported read preference %v", modeStr)
-		}
-	} else {
-		return nil, errors.New("read preference is missing the required \"mode\" field")
-	}
-}
-
-func PinnedServerSelector(addr address.Address) description.ServerSelector {
-	return description.ServerSelectorFunc(func(t description.Topology, candidates []description.Server) ([]description.Server, error) {
-		for _, s := range candidates {
-			if s.Addr == addr {
-				return []description.Server{s}, nil
-			}
-		}
-		return nil, nil
-	})
-}
-
-func (ps *ProxySession) getMongoConnection(rp *readpref.ReadPref) (*MongoConnectionWrapper, error) {
-	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "finding a server")
-	var srvSelector description.ServerSelector
-	if ps.proxy.config.ConnectionMode == util.Cluster {
-		srvSelector = description.ReadPrefSelector(rp)
-	} else {
-		// Direct
-		srvSelector = PinnedServerSelector(address.Address(ps.proxy.config.MongoAddress()))
-	}
-	srv, err := ps.proxy.topology.SelectServer(ps.proxy.Context, srvSelector)
-	if err != nil {
-		return nil, err
-	}
-	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "found a server. connecting")
-	ep, ok := srv.(driver.ErrorProcessor)
-	if !ok {
-		return nil, fmt.Errorf("server ErrorProcessor type assertion failed")
-	}
-	conn, err := srv.Connection(ps.proxy.Context)
-	if err != nil {
-		return nil, err
-	}
-	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "connected")
-	ec, ok := conn.(driver.Expirable)
-	if !ok {
-		return nil, fmt.Errorf("bad connection type %T", conn)
-	}
-	return &MongoConnectionWrapper{conn, ep, ec, false, ps.proxy.logger, ps.proxy.config.TraceConnPool}, nil
-}
-
-func wrapNetworkError(err error) error {
-	labels := []string{driver.NetworkError}
-	return driver.Error{Message: err.Error(), Labels: labels, Wrapped: err}
-}
-
-func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnectionWrapper, error) {
-	var requestDurationHook, responseDurationHook, requestErrorsHook, responseErrorsHook MetricsHook
-
-	if ps.isMetricsEnabled {
-		var ok bool
-		requestDurationHook, ok = ps.hooks["requestDurationHook"]
-		if !ok {
-			return nil, fmt.Errorf("could not access the request processing duration metric hook")
-		}
-		responseDurationHook, ok = ps.hooks["responseDurationHook"]
-		if !ok {
-			return nil, fmt.Errorf("could not access the response processing duration metric hook")
-		}
-		requestErrorsHook, ok = ps.hooks["requestErrorsHook"]
-		if !ok {
-			return nil, fmt.Errorf("could not access the request processing errors metric hook")
-		}
-		responseErrorsHook, ok = ps.hooks["responseErrorsHook"]
-		if !ok {
-			return nil, fmt.Errorf("could not access the response processing errors metric hook")
-		}
-	}
-
-	// reading message from client
-	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client")
-	m, err := ReadMessage(ps.conn)
-	if err != nil {
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client fail %v", err)
-		if ps.isMetricsEnabled {
-			hookErr := requestErrorsHook.IncCounterGauge()
-			if hookErr != nil {
-				ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-			}
-		}
-		if err == io.EOF {
-			return mongoConn, err
-		}
-		return mongoConn, NewStackErrorf("got error reading from client: %v", err)
-	}
-
-	isRequestTimerStarted := false
-	if ps.isMetricsEnabled {
-		hookErr := requestDurationHook.StartTimer()
-		if hookErr != nil {
-			ps.proxy.logger.Logf(slogger.WARN, "failed to start request duration metric hook timer %v", hookErr)
-		} else {
-			isRequestTimerStarted = true
-		}
-	}
-
-	var rp *readpref.ReadPref = ps.proxy.defaultReadPref
-	if ps.proxy.config.ConnectionMode == util.Cluster {
-		// only concerned about OP_MSG at this point
-		mm, ok := m.(*MessageMessage)
-		if ok {
-			rp2, err := getReadPrefFromOpMsg(mm, ps.proxy.logger, rp)
-			if err != nil {
-				if ps.isMetricsEnabled {
-					hookErr := requestErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-					}
-				}
-				return mongoConn, err
-			}
-			if rp2 != nil {
-				rp = rp2
-			}
-		}
-	}
-	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got message from client")
-	ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, m)
-	var respInter ResponseInterceptor
-	if ps.interceptor != nil {
-		ps.interceptor.TrackRequest(m.Header())
-		m, respInter, err = ps.interceptor.InterceptClientToMongo(m)
-		if err != nil {
-			if m == nil {
-				if ps.isMetricsEnabled {
-					hookErr := requestErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-					}
-				}
-				return mongoConn, err
-			}
-			if !m.HasResponse() {
-				// we can't respond, so we just fail
-				if ps.isMetricsEnabled {
-					hookErr := requestErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-					}
-				}
-				return mongoConn, err
-			}
-			if respondErr := ps.RespondWithError(m, err); respondErr != nil {
-				if ps.isMetricsEnabled {
-					hookErr := requestErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-					}
-				}
-				return mongoConn, NewStackErrorf("couldn't send error response to client; original error: %v, error sending response: %v", err, respondErr)
-			}
-			return mongoConn, nil
-		}
-		if m == nil {
-			// already responded
-			return mongoConn, nil
-		}
-	}
-	if mongoConn == nil || !mongoConn.expirableConn.Alive() {
-		mongoConn, err = ps.getMongoConnection(rp)
-		if err != nil {
-			if ps.isMetricsEnabled {
-				hookErr := requestErrorsHook.IncCounterGauge()
-				if hookErr != nil {
-					ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-				}
-			}
-			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to get a new connection. err=%v", err)
-			return nil, NewStackErrorf("cannot get connection to mongo %v using connection mode=%v readpref=%v", err, ps.proxy.config.ConnectionMode, rp)
-		}
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got new connection %v using connection mode=%v readpref=%v", mongoConn.conn.ID(), ps.proxy.config.ConnectionMode, rp)
-	}
-
-	if ps.isMetricsEnabled && isRequestTimerStarted {
-		requestDurationHook.StopTimer()
-	}
-
-	// Send message to mongo
-	err = mongoConn.conn.WriteWireMessage(ps.proxy.Context, m.Serialize())
-	if err != nil {
-		if ps.isMetricsEnabled {
-			hookErr := requestErrorsHook.IncCounterGauge()
-			if hookErr != nil {
-				ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
-			}
-		}
-		mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
-		return mongoConn, NewStackErrorf("error writing to mongo: %v", err)
-	}
-
-	if !m.HasResponse() {
-		return mongoConn, nil
-	}
-	defer mongoConn.Close(ps)
-
-	inExhaustMode := m.IsExhaust()
-
-	for {
-		// Read message back from mongo
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading data from mongo conn %v", mongoConn.conn.ID())
-		ret, err := mongoConn.conn.ReadWireMessage(ps.proxy.Context, nil)
-		if err != nil {
-			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading wire message mongo conn %v %v", mongoConn.conn.ID(), err)
-			if ps.isMetricsEnabled {
-				hookErr := responseErrorsHook.IncCounterGauge()
-				if hookErr != nil {
-					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-				}
-			}
-			mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
-			return nil, NewStackErrorf("error reading wire message from mongo conn %v: %v", mongoConn.conn.ID(), err)
-		}
-
-		isResponseTimerStarted := false
-		if ps.isMetricsEnabled {
-			hookErr := responseDurationHook.StartTimer()
-			if hookErr != nil {
-				ps.proxy.logger.Logf(slogger.WARN, "failed to start reponse duration metric hook timer %v", hookErr)
-			} else {
-				isResponseTimerStarted = true
-			}
-		}
-
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "read data from mongo conn %v", mongoConn.conn.ID())
-		resp, err := ReadMessageFromBytes(ret)
-		if err != nil {
-			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading message from bytes on mongo conn %v %v", mongoConn.conn.ID(), err)
-			if ps.isMetricsEnabled {
-				hookErr := responseErrorsHook.IncCounterGauge()
-				if hookErr != nil {
-					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-				}
-			}
-			if err == io.EOF {
-				return nil, err
-			}
-			return nil, NewStackErrorf("got error reading response from mongo %v", err)
-		}
-		switch mm := resp.(type) {
-		case *MessageMessage:
-			if err := extractError(mm.BodyDoc); err != nil {
-				if ps.isMetricsEnabled {
-					hookErr := responseErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-					}
-				}
-				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
-				mongoConn.ep.ProcessError(err, mongoConn.conn)
-			}
-		case *ReplyMessage:
-			if err := extractError(mm.CommandDoc); err != nil {
-				if ps.isMetricsEnabled {
-					hookErr := responseErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-					}
-				}
-				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn %v", err, mongoConn.conn.ID())
-				mongoConn.ep.ProcessError(err, mongoConn.conn)
-			}
-		}
-		if respInter != nil {
-			resp, err = respInter.InterceptMongoToClient(resp)
-			if err != nil {
-				if ps.isMetricsEnabled {
-					hookErr := responseErrorsHook.IncCounterGauge()
-					if hookErr != nil {
-						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-					}
-				}
-				return nil, NewStackErrorf("error intercepting message %v", err)
-			}
-		}
-
-		ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, resp)
-		if ps.isMetricsEnabled && isResponseTimerStarted {
-			responseDurationHook.StopTimer()
-		}
-
-		// Send message back to user
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sending back data to user from mongo conn %v", mongoConn.conn.ID())
-		err = SendMessage(resp, ps.conn)
-		if err != nil {
-			if ps.isMetricsEnabled {
-				hookErr := responseErrorsHook.IncCounterGauge()
-				if hookErr != nil {
-					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-				}
-			}
-			mongoConn.bad = true
-			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got error sending response to client from conn %v. err=%v", mongoConn.conn.ID(), err)
-			return nil, NewStackErrorf("got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
-		}
-		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sent back data to user from mongo conn %v", mongoConn.conn.ID())
-		if ps.interceptor != nil {
-			ps.interceptor.TrackResponse(resp.Header())
-		}
-
-		if !inExhaustMode {
-			return nil, nil
-		}
-
-		switch r := resp.(type) {
-		case *ReplyMessage:
-			if r.CursorId == 0 {
-				return nil, nil
-			}
-		case *MessageMessage:
-			if !r.HasMoreToCome() {
-				// moreToCome wasn't set - stop the loop
-				return nil, nil
-			}
-		default:
-			if ps.isMetricsEnabled {
-				hookErr := responseErrorsHook.IncCounterGauge()
-				if hookErr != nil {
-					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
-				}
-			}
-			return nil, NewStackErrorf("bad response type from server %T", r)
-		}
-	}
-}
-
 func NewProxy(pc ProxyConfig) (Proxy, error) {
 	ctx := context.Background()
 	var initCount, initPoolCleared int64 = 0, 0
 	defaultReadPref := readpref.Primary()
-	p := Proxy{pc, nil, nil, nil, nil, defaultReadPref, ctx, &initCount, &initPoolCleared}
-	mongoClient, err := getMongoClient(&p, pc, ctx)
+	p := Proxy{pc, nil, nil, nil, nil, defaultReadPref, ctx, &initCount, &initPoolCleared, sync.Map{}}
+	mongoClient, err := getMongoClientFromProxyConfig(&p, pc, ctx)
 	if err != nil {
 		return Proxy{}, NewStackErrorf("error getting driver client for %v: %v", pc.MongoAddress(), err)
 	}
@@ -701,7 +80,46 @@ func NewProxy(pc ProxyConfig) (Proxy, error) {
 	return p, nil
 }
 
-func getMongoClient(p *Proxy, pc ProxyConfig, ctx context.Context) (*mongo.Client, error) {
+func getMongoClientFromUri(p *Proxy, uri, appName string, trace bool, serverSelectionTimeoutSec, maxPoolSize int, rootCAs *x509.CertPool, ctx context.Context) (*mongo.Client, error) {
+	opts := options.Client()
+	opts.ApplyURI(uri).
+		SetAppName(appName).
+		SetPoolMonitor(&event.PoolMonitor{
+			Event: func(evt *event.PoolEvent) {
+				switch evt.Type {
+				case event.ConnectionCreated:
+					if trace {
+						p.logger.Logf(slogger.DEBUG, "**** Connection created %v", evt)
+					}
+					p.AddConnection()
+				case "ConnectionCheckOutStarted":
+					if trace {
+						p.logger.Logf(slogger.DEBUG, "**** Connection check out started %v", evt)
+					}
+				case "ConnectionCheckedIn":
+					if trace {
+						p.logger.Logf(slogger.DEBUG, "**** Connection checked in %v", evt)
+					}
+				case "ConnectionCheckedOut":
+					if trace {
+						p.logger.Logf(slogger.DEBUG, "**** Connection checked out %v", evt)
+					}
+				case event.PoolCleared:
+					p.IncrementPoolCleared()
+				}
+			},
+		}).
+		SetServerSelectionTimeout(time.Duration(serverSelectionTimeoutSec) * time.Second).
+		SetMaxPoolSize(uint64(maxPoolSize))
+	if rootCAs != nil {
+		tlsConfig := &tls.Config{RootCAs: rootCAs}
+		opts.SetTLSConfig(tlsConfig)
+	}
+	// TODO - confirm we're getting auth
+	return mongo.Connect(ctx, opts)
+}
+
+func getMongoClientFromProxyConfig(p *Proxy, pc ProxyConfig, ctx context.Context) (*mongo.Client, error) {
 	opts := options.Client()
 	if pc.ConnectionMode == util.Direct {
 		opts.ApplyURI(fmt.Sprintf("mongodb://%s", pc.MongoAddress()))
@@ -761,6 +179,37 @@ func getMongoClient(p *Proxy, pc ProxyConfig, ctx context.Context) (*mongo.Clien
 		opts.SetTLSConfig(tlsConfig)
 	}
 	return mongo.Connect(ctx, opts)
+}
+
+func (p *Proxy) AddRemoteConnection(rsName, uri, appName string, trace bool, serverSelectionTimeoutSec, maxPoolSize int, rootCAs *x509.CertPool) error {
+	p.logger.Logf(slogger.DEBUG, "adding remote connection for %s", rsName)
+	if _, ok := p.remoteConnections.Load(rsName); ok {
+		p.logger.Logf(slogger.DEBUG, "remote connection for %s already exists", rsName)
+		return nil
+	}
+	client, err := getMongoClientFromUri(p, uri, appName, trace, serverSelectionTimeoutSec, maxPoolSize, rootCAs, p.Context)
+	if err != nil {
+		return err
+	}
+	p.remoteConnections.Store(rsName, &RemoteConnection{client, extractTopology(client)})
+	return nil
+}
+
+func (p *Proxy) ClearRemoteConnection(rsName string, additionalGracePeriodSec int) error {
+	rc, ok := p.remoteConnections.Load(rsName)
+	if !ok {
+		p.logger.Logf(slogger.WARN, "remote connection for %s doesn't exist", rsName)
+		return nil
+	}
+	p.logger.Logf(slogger.DEBUG, "clearing remote connection for %s", rsName)
+	ctx2, cancelFn := context.WithTimeout(p.Context, time.Duration(additionalGracePeriodSec)*time.Second)
+	defer cancelFn()
+	// remote connections only has *mongo.Client, so no need for type check here. being extra safe about null clients just in case.
+	if rc.(*RemoteConnection).client != nil {
+		return rc.(*RemoteConnection).client.Disconnect(ctx2)
+	}
+	p.logger.Logf(slogger.DEBUG, "remote connection client is nil")
+	return nil
 }
 
 func (p *Proxy) InitializeServer() {

--- a/proxy.go
+++ b/proxy.go
@@ -36,7 +36,7 @@ type Proxy struct {
 	poolCleared        *int64
 
 	// using a sync.Map instead of a map paired with mutex because sync.Map is optimized for cases in which the access pattern is predominant by reads
-	remoteConnections sync.Map
+	remoteConnections *sync.Map
 }
 
 type RemoteConnection struct {
@@ -67,7 +67,7 @@ func NewProxy(pc ProxyConfig) (Proxy, error) {
 	ctx := context.Background()
 	var initCount, initPoolCleared int64 = 0, 0
 	defaultReadPref := readpref.Primary()
-	p := Proxy{pc, nil, nil, nil, nil, defaultReadPref, ctx, &initCount, &initPoolCleared, sync.Map{}}
+	p := Proxy{pc, nil, nil, nil, nil, defaultReadPref, ctx, &initCount, &initPoolCleared, &sync.Map{}}
 	mongoClient, err := getMongoClientFromProxyConfig(&p, pc, ctx)
 	if err != nil {
 		return Proxy{}, NewStackErrorf("error getting driver client for %v: %v", pc.MongoAddress(), err)

--- a/proxy.go
+++ b/proxy.go
@@ -120,6 +120,7 @@ func getBaseClientOptions(p *Proxy, uri, appName string, trace bool, serverSelec
 	return opts
 }
 
+// should be used by remote connections
 func getMongoClientFromUri(p *Proxy, uri, appName string, trace bool, serverSelectionTimeoutSec, maxPoolSize, maxPoolIdleTimeSec, connectionPoolHeartbeatIntervalMs int, rootCAs *x509.CertPool, ctx context.Context) (*mongo.Client, error) {
 	opts := getBaseClientOptions(p, uri, appName, trace, serverSelectionTimeoutSec, maxPoolSize, maxPoolIdleTimeSec, connectionPoolHeartbeatIntervalMs)
 	if rootCAs != nil {
@@ -129,6 +130,7 @@ func getMongoClientFromUri(p *Proxy, uri, appName string, trace bool, serverSele
 	return mongo.Connect(ctx, opts)
 }
 
+// should be used by local connections
 func getMongoClientFromProxyConfig(p *Proxy, pc ProxyConfig, ctx context.Context) (*mongo.Client, error) {
 	var uri string
 	if pc.ConnectionMode == util.Direct {
@@ -159,7 +161,7 @@ func getMongoClientFromProxyConfig(p *Proxy, pc ProxyConfig, ctx context.Context
 
 func (p *Proxy) AddRemoteConnection(rsName, uri, appName string, trace bool, serverSelectionTimeoutSec, maxPoolSize, maxPoolIdleTimeSec, connectionPoolHeartbeatIntervalMs int, rootCAs *x509.CertPool) error {
 	p.logger.Logf(slogger.DEBUG, "adding remote connection for %s", rsName)
-	if _, ok := p.remoteConnections.Load(rsName); ok {
+	if _, alreadyAdded := p.remoteConnections.Load(rsName); alreadyAdded {
 		p.logger.Logf(slogger.DEBUG, "remote connection for %s already exists", rsName)
 		return nil
 	}

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -1,0 +1,657 @@
+package mongonet
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	"github.com/mongodb/mongonet/util"
+	"github.com/mongodb/slogger/v2/slogger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+)
+
+type ProxySession struct {
+	*Session
+
+	proxy            *Proxy
+	interceptor      ProxyInterceptor
+	hooks            map[string]MetricsHook
+	mongoConn        *MongoConnectionWrapper
+	isMetricsEnabled bool
+}
+
+type MetricsHook interface {
+	StartTimer() error
+	StopTimer()
+	SetGauge(val float64) error
+	AddCounterGauge(val float64) error
+	SubGauge(val float64) error
+	IncCounterGauge() error
+	DecGauge() error
+}
+
+type MetricsHookFactory interface {
+	NewHook(metricName, labelName, labelValue string) (MetricsHook, error)
+}
+
+type ResponseInterceptor interface {
+	InterceptMongoToClient(m Message) (Message, error)
+}
+
+type ProxyInterceptor interface {
+	InterceptClientToMongo(m Message) (newMsg Message, ri ResponseInterceptor, remoteRs string, err error)
+	Close()
+	TrackRequest(MessageHeader)
+	TrackResponse(MessageHeader)
+	CheckConnection() error
+	CheckConnectionInterval() time.Duration
+}
+
+type ProxyInterceptorFactory interface {
+	// This has to be thread safe, will be called from many clients
+	NewInterceptor(ps *ProxySession) (ProxyInterceptor, error)
+}
+
+// -----
+
+func (ps *ProxySession) RemoteAddr() net.Addr {
+	return ps.remoteAddr
+}
+
+func (ps *ProxySession) GetLogger() *slogger.Logger {
+	return ps.logger
+}
+
+func (ps *ProxySession) ServerPort() int {
+	return ps.proxy.config.BindPort
+}
+
+func (ps *ProxySession) Stats() bson.D {
+	return bson.D{
+		{"connectionPool", bson.D{
+			{"totalCreated", ps.proxy.GetConnectionsCreated()},
+		},
+		},
+	}
+}
+
+func (ps *ProxySession) DoLoopTemp() {
+	defer logPanic(ps.logger)
+	var err error
+	for {
+		ps.mongoConn, err = ps.doLoop(ps.mongoConn)
+		if err != nil {
+			if ps.mongoConn != nil {
+				ps.mongoConn.Close(ps)
+			}
+			if err != io.EOF {
+				ps.logger.Logf(slogger.WARN, "error doing loop: %v", err)
+			}
+			return
+		}
+	}
+}
+
+func (ps *ProxySession) respondWithError(clientMessage Message, err error) error {
+	ps.logger.Logf(slogger.INFO, "respondWithError %v", err)
+
+	var errBSON bson.D
+	if err == nil {
+		errBSON = bson.D{{"ok", 1}}
+	} else if mongoErr, ok := err.(MongoError); ok {
+		errBSON = mongoErr.ToBSON()
+	} else {
+		errBSON = bson.D{{"ok", 0}, {"errmsg", err.Error()}}
+	}
+
+	doc, myErr := SimpleBSONConvert(errBSON)
+	if myErr != nil {
+		return myErr
+	}
+
+	switch clientMessage.Header().OpCode {
+	case OP_QUERY, OP_GET_MORE:
+		rm := &ReplyMessage{
+			MessageHeader{
+				0,
+				17, // TODO
+				clientMessage.Header().RequestID,
+				OP_REPLY},
+
+			// We should not set the error bit because we are
+			// responding with errmsg instead of $err
+			0, // flags - error bit
+
+			0, // cursor id
+			0, // StartingFrom
+			1, // NumberReturned
+			[]SimpleBSON{doc},
+			bsoncore.Document(doc.BSON),
+		}
+		return SendMessage(rm, ps.conn)
+
+	case OP_COMMAND:
+		rm := &CommandReplyMessage{
+			MessageHeader{
+				0,
+				17, // TODO
+				clientMessage.Header().RequestID,
+				OP_COMMAND_REPLY},
+			doc,
+			SimpleBSONEmpty(),
+			[]SimpleBSON{},
+		}
+		return SendMessage(rm, ps.conn)
+
+	case OP_MSG:
+		rm := &MessageMessage{
+			MessageHeader{
+				0,
+				17, // TODO
+				clientMessage.Header().RequestID,
+				OP_MSG},
+			0,
+			[]MessageMessageSection{
+				&BodySection{
+					doc,
+				},
+			},
+			bsoncore.Document(doc.BSON),
+		}
+		return SendMessage(rm, ps.conn)
+
+	default:
+		panic(fmt.Sprintf("unsupported opcode %v", clientMessage.Header().OpCode))
+	}
+}
+
+func (ps *ProxySession) Close() {
+	if ps.interceptor != nil {
+		ps.interceptor.Close()
+	}
+}
+
+func logPanic(logger *slogger.Logger) {
+	if r := recover(); r != nil {
+		var stacktraces bytes.Buffer
+		pprof.Lookup("goroutine").WriteTo(&stacktraces, 2)
+		logger.Logf(slogger.ERROR, "Recovering from mongonet panic. error is: %v \n stack traces: %v", r, stacktraces.String())
+		logger.Flush()
+		panic(r)
+	}
+}
+
+func getReadPrefFromOpMsg(mm *MessageMessage, logger *slogger.Logger, defaultRp *readpref.ReadPref) (rp *readpref.ReadPref, err error) {
+	rpVal, err2 := mm.BodyDoc.LookupErr("$readPreference")
+	if err2 != nil {
+		if err2 == bsoncore.ErrElementNotFound {
+			return defaultRp, nil
+		}
+		return nil, fmt.Errorf("got an error looking up $readPreference: %v", err)
+	}
+	rpDoc, ok := rpVal.DocumentOK()
+	if !ok {
+		return nil, fmt.Errorf("$readPreference isn't a document")
+	}
+	opts := make([]readpref.Option, 0, 1)
+	if maxStalenessVal, err := rpDoc.LookupErr("maxStalenessSeconds"); err == nil {
+		if maxStalenessSec, ok := maxStalenessVal.AsInt32OK(); ok && maxStalenessSec >= MinMaxStalenessVal {
+			opts = append(opts, readpref.WithMaxStaleness(time.Duration(maxStalenessSec)*time.Second))
+		} else {
+			return nil, fmt.Errorf("maxStalenessSeconds %v is invalid", maxStalenessVal)
+		}
+	}
+	if modeVal, err2 := rpDoc.LookupErr("mode"); err2 == nil {
+		modeStr, ok := modeVal.StringValueOK()
+		if !ok {
+			return nil, fmt.Errorf("mode %v isn't a string", modeVal)
+		}
+		switch strings.ToLower(modeStr) {
+		case "primarypreferred":
+			return readpref.PrimaryPreferred(opts...), nil
+		case "secondary":
+			return readpref.Secondary(opts...), nil
+		case "secondarypreferred":
+			return readpref.SecondaryPreferred(opts...), nil
+		case "nearest":
+			return readpref.Nearest(opts...), nil
+		case "primary":
+			return defaultRp, nil
+		default:
+			return nil, fmt.Errorf("got unsupported read preference %v", modeStr)
+		}
+	} else {
+		return nil, errors.New("read preference is missing the required \"mode\" field")
+	}
+}
+
+func PinnedServerSelector(addr address.Address) description.ServerSelector {
+	return description.ServerSelectorFunc(func(t description.Topology, candidates []description.Server) ([]description.Server, error) {
+		for _, s := range candidates {
+			if s.Addr == addr {
+				return []description.Server{s}, nil
+			}
+		}
+		return nil, nil
+	})
+}
+
+func (ps *ProxySession) getMongoConnection(rp *readpref.ReadPref, topology *topology.Topology) (*MongoConnectionWrapper, error) {
+	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "finding a server")
+	var srvSelector description.ServerSelector
+	if ps.proxy.config.ConnectionMode == util.Cluster {
+		srvSelector = description.ReadPrefSelector(rp)
+	} else {
+		// Direct
+		srvSelector = PinnedServerSelector(address.Address(ps.proxy.config.MongoAddress()))
+	}
+	srv, err := topology.SelectServer(ps.proxy.Context, srvSelector)
+	if err != nil {
+		return nil, err
+	}
+	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "found a server. connecting")
+	ep, ok := srv.(driver.ErrorProcessor)
+	if !ok {
+		return nil, fmt.Errorf("server ErrorProcessor type assertion failed")
+	}
+	conn, err := srv.Connection(ps.proxy.Context)
+	if err != nil {
+		return nil, err
+	}
+	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "connected to %v", conn.Address())
+	ec, ok := conn.(driver.Expirable)
+	if !ok {
+		return nil, fmt.Errorf("bad connection type %T", conn)
+	}
+	return &MongoConnectionWrapper{conn, ep, ec, false, ps.proxy.logger, ps.proxy.config.TraceConnPool}, nil
+}
+
+func wrapNetworkError(err error) error {
+	labels := []string{driver.NetworkError}
+	return driver.Error{Message: err.Error(), Labels: labels, Wrapped: err}
+}
+
+func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnectionWrapper, error) {
+	var requestDurationHook, responseDurationHook, requestErrorsHook, responseErrorsHook MetricsHook
+
+	if ps.isMetricsEnabled {
+		var ok bool
+		requestDurationHook, ok = ps.hooks["requestDurationHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the request processing duration metric hook")
+		}
+		responseDurationHook, ok = ps.hooks["responseDurationHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the response processing duration metric hook")
+		}
+		requestErrorsHook, ok = ps.hooks["requestErrorsHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the request processing errors metric hook")
+		}
+		responseErrorsHook, ok = ps.hooks["responseErrorsHook"]
+		if !ok {
+			return nil, fmt.Errorf("could not access the response processing errors metric hook")
+		}
+	}
+
+	// reading message from client
+	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client")
+	m, err := ReadMessage(ps.conn)
+	if err != nil {
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading message from client fail %v", err)
+		if ps.isMetricsEnabled {
+			hookErr := requestErrorsHook.IncCounterGauge()
+			if hookErr != nil {
+				ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+			}
+		}
+		if err == io.EOF {
+			return mongoConn, err
+		}
+		return mongoConn, NewStackErrorf("got error reading from client: %v", err)
+	}
+
+	isRequestTimerStarted := false
+	if ps.isMetricsEnabled {
+		hookErr := requestDurationHook.StartTimer()
+		if hookErr != nil {
+			ps.proxy.logger.Logf(slogger.WARN, "failed to start request duration metric hook timer %v", hookErr)
+		} else {
+			isRequestTimerStarted = true
+		}
+	}
+
+	var rp *readpref.ReadPref = ps.proxy.defaultReadPref
+	if ps.proxy.config.ConnectionMode == util.Cluster {
+		// only concerned about OP_MSG at this point
+		mm, ok := m.(*MessageMessage)
+		if ok {
+			rp2, err := getReadPrefFromOpMsg(mm, ps.proxy.logger, rp)
+			if err != nil {
+				if ps.isMetricsEnabled {
+					hookErr := requestErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+					}
+				}
+				return mongoConn, err
+			}
+			if rp2 != nil {
+				rp = rp2
+			}
+		}
+	}
+	ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got message from client")
+	ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, m)
+	var respInter ResponseInterceptor
+	var remoteRs string
+	if ps.interceptor != nil {
+		ps.interceptor.TrackRequest(m.Header())
+		m, respInter, remoteRs, err = ps.interceptor.InterceptClientToMongo(m)
+		if err != nil {
+			if m == nil {
+				if ps.isMetricsEnabled {
+					hookErr := requestErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+					}
+				}
+				return mongoConn, err
+			}
+			if !m.HasResponse() {
+				// we can't respond, so we just fail
+				if ps.isMetricsEnabled {
+					hookErr := requestErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+					}
+				}
+				return mongoConn, err
+			}
+			if respondErr := ps.RespondWithError(m, err); respondErr != nil {
+				if ps.isMetricsEnabled {
+					hookErr := requestErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+					}
+				}
+				return mongoConn, NewStackErrorf("couldn't send error response to client; original error: %v, error sending response: %v", err, respondErr)
+			}
+			return mongoConn, nil
+		}
+		if m == nil {
+			// already responded
+			return mongoConn, nil
+		}
+	}
+	if mongoConn == nil || !mongoConn.expirableConn.Alive() {
+		var topology *topology.Topology
+		if remoteRs == "" {
+			topology = ps.proxy.topology
+		} else {
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "getting remote connection for %s", remoteRs)
+			rc, ok := ps.proxy.remoteConnections.Load(remoteRs)
+			if !ok {
+				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to get a new remote connection to %s as it wasn't initialized", remoteRs)
+				return nil, NewStackErrorf("failed to get a new remote connection to %s as it wasn't initialized", remoteRs)
+			}
+			topology = rc.(*RemoteConnection).topology
+		}
+		mongoConn, err = ps.getMongoConnection(rp, topology)
+		if err != nil {
+			if ps.isMetricsEnabled {
+				hookErr := requestErrorsHook.IncCounterGauge()
+				if hookErr != nil {
+					ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+				}
+			}
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "failed to get a new connection. err=%v", err)
+			return nil, NewStackErrorf("cannot get connection to mongo %v using connection mode=%v readpref=%v remoteRs=%s", err, ps.proxy.config.ConnectionMode, rp, remoteRs)
+		}
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got new connection %v using connection mode=%v readpref=%v remoteRs=%s", mongoConn.conn.ID(), ps.proxy.config.ConnectionMode, rp, remoteRs)
+	}
+
+	if ps.isMetricsEnabled && isRequestTimerStarted {
+		requestDurationHook.StopTimer()
+	}
+
+	// Send message to mongo
+	err = mongoConn.conn.WriteWireMessage(ps.proxy.Context, m.Serialize())
+	if err != nil {
+		if ps.isMetricsEnabled {
+			hookErr := requestErrorsHook.IncCounterGauge()
+			if hookErr != nil {
+				ps.proxy.logger.Logf(slogger.WARN, "failed to increment requestErrorsHook %v", hookErr)
+			}
+		}
+		mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
+		return mongoConn, NewStackErrorf("error writing to mongo: %v", err)
+	}
+
+	if !m.HasResponse() {
+		return mongoConn, nil
+	}
+	defer mongoConn.Close(ps)
+
+	inExhaustMode := m.IsExhaust()
+
+	for {
+		// Read message back from mongo
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "reading data from mongo conn id=%v remoteRs=%s", mongoConn.conn.ID(), remoteRs)
+		ret, err := mongoConn.conn.ReadWireMessage(ps.proxy.Context, nil)
+		if err != nil {
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading wire message mongo conn id=%v remoteRs=%s. err=%v", mongoConn.conn.ID(), remoteRs, err)
+			if ps.isMetricsEnabled {
+				hookErr := responseErrorsHook.IncCounterGauge()
+				if hookErr != nil {
+					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+				}
+			}
+			mongoConn.ep.ProcessError(wrapNetworkError(err), mongoConn.conn)
+			return nil, NewStackErrorf("error reading wire message from mongo conn id=%v remoteRs=%s. err=%v", mongoConn.conn.ID(), remoteRs, err)
+		}
+
+		isResponseTimerStarted := false
+		if ps.isMetricsEnabled {
+			hookErr := responseDurationHook.StartTimer()
+			if hookErr != nil {
+				ps.proxy.logger.Logf(slogger.WARN, "failed to start reponse duration metric hook timer %v", hookErr)
+			} else {
+				isResponseTimerStarted = true
+			}
+		}
+
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "read data from mongo conn %v", mongoConn.conn.ID())
+		resp, err := ReadMessageFromBytes(ret)
+		if err != nil {
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "error reading message from bytes on mongo conn id=%v remoteRs=%s. err=%v", mongoConn.conn.ID(), remoteRs, err)
+			if ps.isMetricsEnabled {
+				hookErr := responseErrorsHook.IncCounterGauge()
+				if hookErr != nil {
+					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+				}
+			}
+			if err == io.EOF {
+				return nil, err
+			}
+			return nil, NewStackErrorf("got error reading response from mongo %v", err)
+		}
+		switch mm := resp.(type) {
+		case *MessageMessage:
+			if err := extractError(mm.BodyDoc); err != nil {
+				if ps.isMetricsEnabled {
+					hookErr := responseErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+					}
+				}
+				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn id=%v remoteRs=%s", err, mongoConn.conn.ID(), remoteRs)
+				mongoConn.ep.ProcessError(err, mongoConn.conn)
+			}
+		case *ReplyMessage:
+			if err := extractError(mm.CommandDoc); err != nil {
+				if ps.isMetricsEnabled {
+					hookErr := responseErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+					}
+				}
+				ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "processing error %v on mongo conn id=%v remoteRs=%s", err, mongoConn.conn.ID(), remoteRs)
+				mongoConn.ep.ProcessError(err, mongoConn.conn)
+			}
+		}
+		if respInter != nil {
+			resp, err = respInter.InterceptMongoToClient(resp)
+			if err != nil {
+				if ps.isMetricsEnabled {
+					hookErr := responseErrorsHook.IncCounterGauge()
+					if hookErr != nil {
+						ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+					}
+				}
+				return nil, NewStackErrorf("error intercepting message %v", err)
+			}
+		}
+
+		ps.logMessageTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, resp)
+		if ps.isMetricsEnabled && isResponseTimerStarted {
+			responseDurationHook.StopTimer()
+		}
+
+		// Send message back to user
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sending back data to user from mongo conn id=%v remoteRs=%s", mongoConn.conn.ID(), remoteRs)
+		err = SendMessage(resp, ps.conn)
+		if err != nil {
+			if ps.isMetricsEnabled {
+				hookErr := responseErrorsHook.IncCounterGauge()
+				if hookErr != nil {
+					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+				}
+			}
+			mongoConn.bad = true
+			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "got error sending response to client from conn id=%v remoteRs=%s. err=%v", mongoConn.conn.ID(), remoteRs, err)
+			return nil, NewStackErrorf("got error sending response to client from conn %v: %v", mongoConn.conn.ID(), err)
+		}
+		ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "sent back data to user from mongo conn id=%v remoteRs=%s", mongoConn.conn.ID(), remoteRs)
+		if ps.interceptor != nil {
+			ps.interceptor.TrackResponse(resp.Header())
+		}
+
+		if !inExhaustMode {
+			return nil, nil
+		}
+
+		switch r := resp.(type) {
+		case *ReplyMessage:
+			if r.CursorId == 0 {
+				return nil, nil
+			}
+		case *MessageMessage:
+			if !r.HasMoreToCome() {
+				// moreToCome wasn't set - stop the loop
+				return nil, nil
+			}
+		default:
+			if ps.isMetricsEnabled {
+				hookErr := responseErrorsHook.IncCounterGauge()
+				if hookErr != nil {
+					ps.proxy.logger.Logf(slogger.WARN, "failed to increment responseErrorsHook %v", hookErr)
+				}
+			}
+			return nil, NewStackErrorf("bad response type from server %T", r)
+		}
+	}
+}
+
+func (ps *ProxySession) logTrace(logger *slogger.Logger, trace bool, format string, args ...interface{}) {
+	if trace {
+		msg := fmt.Sprintf(fmt.Sprintf("client: %v - %s", ps.RemoteAddr(), format), args...)
+		logger.Logf(slogger.DEBUG, msg)
+	}
+}
+
+func (ps *ProxySession) logMessageTrace(logger *slogger.Logger, trace bool, m Message) {
+	if trace {
+		var doc bson.D
+		var msg string
+		var err error
+		switch mm := m.(type) {
+		case *MessageMessage:
+			for _, section := range mm.Sections {
+				if bs, ok := section.(*BodySection); ok {
+					doc, err = bs.Body.ToBSOND()
+					if err != nil {
+						logger.Logf(slogger.WARN, "failed to convert body to Bson.D. err=%v", err)
+						return
+					}
+					break
+				}
+			}
+			msg = fmt.Sprintf("got OP_MSG %v", doc)
+		case *QueryMessage:
+			doc, err = mm.Query.ToBSOND()
+			if err != nil {
+				logger.Logf(slogger.WARN, "failed to convert query to Bson.D. err=%v", err)
+				return
+			}
+			msg = fmt.Sprintf("got OP_QUERY %v", doc)
+		case *ReplyMessage:
+			doc, err = mm.Docs[0].ToBSOND()
+			if err != nil {
+				logger.Logf(slogger.WARN, "failed to convert reply doc to Bson.D. err=%v", err)
+				return
+			}
+			msg = fmt.Sprintf("got OP_REPLY %v", doc)
+		default:
+			// not bothering about printing other message types
+			msg = fmt.Sprintf("got another type %T", mm)
+		}
+		msg = fmt.Sprintf("client: %v - %s", ps.RemoteAddr(), msg)
+		logger.Logf(slogger.DEBUG, msg)
+	}
+}
+
+// MongoConnectionWrapper is used to wrap the driver connection so we can explicitly expire (close out) connections on certain occasions that aren't being picked up by the driver
+type MongoConnectionWrapper struct {
+	conn          driver.Connection
+	ep            driver.ErrorProcessor
+	expirableConn driver.Expirable
+	bad           bool
+	logger        *slogger.Logger
+	trace         bool
+}
+
+func (m *MongoConnectionWrapper) Close(ps *ProxySession) {
+	if m.conn == nil {
+		m.logger.Logf(slogger.WARN, "attempt to close a nil mongo connection. noop")
+		return
+	}
+	id := m.conn.ID()
+	if m.bad {
+		if m.expirableConn.Alive() {
+			ps.logTrace(m.logger, m.trace, "closing underlying bad mongo connection %v", id)
+			if err := m.expirableConn.Expire(); err != nil {
+				ps.logTrace(m.logger, m.trace, "failed to expire connection. %v", err)
+			}
+		} else {
+			ps.logTrace(m.logger, m.trace, "bad mongo connection is nil!")
+		}
+	}
+	ps.logTrace(m.logger, m.trace, "closing mongo connection %v", id)
+	if m.expirableConn.Alive() {
+		if err := m.conn.Close(); err != nil {
+			ps.logTrace(m.logger, m.trace, "failed to close mongo connection %v: %v", id, err)
+		}
+	}
+}

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -396,10 +396,8 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		}
 	}
 	if mongoConn == nil || !mongoConn.expirableConn.Alive() {
-		var topology *topology.Topology
-		if remoteRs == "" {
-			topology = ps.proxy.topology
-		} else {
+		topology := ps.proxy.topology
+		if remoteRs != "" {
 			ps.logTrace(ps.proxy.logger, ps.proxy.config.TraceConnPool, "getting remote connection for %s", remoteRs)
 			rc, ok := ps.proxy.remoteConnections.Load(remoteRs)
 			if !ok {

--- a/util/test_utils.go
+++ b/util/test_utils.go
@@ -14,7 +14,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
-const ClientTimeoutSecForTests = 20 * time.Second
+const (
+	ClientTimeoutSecForTests = 20 * time.Second
+	RemoteDbNameForTests     = "testRemote"
+)
 
 type ClientFactoryFunc func(host string, port int, mode MongoConnectionMode, secondaryReads bool, appName string, ctx context.Context) (*mongo.Client, error)
 


### PR DESCRIPTION
This PR adds the ability to use the proxy over multiple (remote) connections.

The remote connection pool needs to be initialized first by running:
`proxy.AddRemoteConnection(rsName, uri, appName string, trace bool, serverSelectionTimeoutSec, maxPoolSize int, rootCAs *x509.CertPool)`

Then it can be used by passing back the required `rsName` from `InterceptClientToMongo()`. Empty `rsName` indicates the proxy should use the default (local) connection.

Finally, the remote connection should be cleared by `proxy.ClearRemoteConnection(rsName)`.