### PR TITLE
Cursor server association support

### DIFF
--- a/cmd/sni_tester/sni_tester.go
+++ b/cmd/sni_tester/sni_tester.go
@@ -44,33 +44,39 @@ func (myi *MyInterceptor) SetClientMessage(message mongonet.Message) {
 	return
 }
 
-func (myi *MyInterceptor) InterceptClientToMongo(m mongonet.Message) (mongonet.Message, mongonet.ResponseInterceptor, string, error) {
+func (myi *MyInterceptor) InterceptClientToMongo(m mongonet.Message) (
+	mongonet.Message,
+	mongonet.ResponseInterceptor,
+	string,
+	address.Address,
+	error,
+	) {
 	switch mm := m.(type) {
 	case *mongonet.QueryMessage:
 		if !mongonet.NamespaceIsCommand(mm.Namespace) {
-			return m, nil, "", nil
+			return m, nil, "", "", nil
 		}
 
 		query, err := mm.Query.ToBSOND()
 		if err != nil || len(query) == 0 {
 			// let mongod handle error message
-			return m, nil, "", nil
+			return m, nil, "", "", nil
 		}
 
 		cmdName := query[0].Key
 		if cmdName != "sni" {
-			return m, nil, "", nil
+			return m, nil, "", "", nil
 		}
 
 		return nil, nil, "", newSNIError(myi.ps.RespondToCommand(mm, myi.sniResponse()))
 	case *mongonet.CommandMessage:
 		if mm.CmdName != "sni" {
-			return mm, nil, "", nil
+			return mm, nil, "", "", nil
 		}
-		return nil, nil, "", newSNIError(myi.ps.RespondToCommand(mm, myi.sniResponse()))
+		return nil, nil, "", "", newSNIError(myi.ps.RespondToCommand(mm, myi.sniResponse()))
 	}
 
-	return m, nil, "", nil
+	return m, nil, "", "", nil
 }
 
 func (myi *MyInterceptor) Close() {

--- a/cmd/sni_tester/sni_tester.go
+++ b/cmd/sni_tester/sni_tester.go
@@ -50,7 +50,7 @@ func (myi *MyInterceptor) InterceptClientToMongo(m mongonet.Message) (
 	string,
 	address.Address,
 	error,
-	) {
+) {
 	switch mm := m.(type) {
 	case *mongonet.QueryMessage:
 		if !mongonet.NamespaceIsCommand(mm.Namespace) {

--- a/cmd/sni_tester/sni_tester.go
+++ b/cmd/sni_tester/sni_tester.go
@@ -69,7 +69,7 @@ func (myi *MyInterceptor) InterceptClientToMongo(m mongonet.Message) (
 			return m, nil, "", "", nil
 		}
 
-		return nil, nil, "", newSNIError(myi.ps.RespondToCommand(mm, myi.sniResponse()))
+		return nil, nil, "", "", newSNIError(myi.ps.RespondToCommand(mm, myi.sniResponse()))
 	case *mongonet.CommandMessage:
 		if mm.CmdName != "sni" {
 			return mm, nil, "", "", nil

--- a/cmd/sni_tester/sni_tester.go
+++ b/cmd/sni_tester/sni_tester.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mongodb/mongonet"
 	"github.com/mongodb/mongonet/util"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
 )
 
 const (

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
 )
 
 const (
@@ -56,7 +57,7 @@ type SimulateRetryFixer struct {
 	OriginalMessage Message
 }
 
-func (srf *SimulateRetryFixer) InterceptMongoToClient(m Message) (Message, error) {
+func (srf *SimulateRetryFixer) InterceptMongoToClient(m Message, _ address.Address) (Message, error) {
 	switch mm := m.(type) {
 	case *MessageMessage:
 		var err error
@@ -158,7 +159,7 @@ func fixIsMasterDirect(doc bson.D, mongoPort, proxyPort int) (SimpleBSON, error)
 	return SimpleBSONConvert(doc)
 }
 
-func (mri *IsMasterFixer) InterceptMongoToClient(m Message) (Message, error) {
+func (mri *IsMasterFixer) InterceptMongoToClient(m Message, _ address.Address) (Message, error) {
 	switch mm := m.(type) {
 	case *ReplyMessage:
 		var err error

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -288,7 +288,7 @@ func (myi *MyInterceptor) InterceptClientToMongo(m Message) (
 			panic(err)
 		}
 		mm.Query = qb
-		return mm, &IsMasterFixer{myi.mode, myi.mongoPort, myi.proxyPort}, "", nil
+		return mm, &IsMasterFixer{myi.mode, myi.mongoPort, myi.proxyPort}, "", "", nil
 	case *MessageMessage:
 		var err error
 		var bodySection *BodySection = nil

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -254,7 +254,7 @@ func (myi *MyInterceptor) InterceptClientToMongo(m Message) (
 	string,
 	address.Address,
 	error,
-	) {
+) {
 	switch mm := m.(type) {
 	case *QueryMessage:
 		if !NamespaceIsCommand(mm.Namespace) {

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -248,7 +248,13 @@ func (myi *MyInterceptor) CheckConnectionInterval() time.Duration {
 	return 0
 }
 
-func (myi *MyInterceptor) InterceptClientToMongo(m Message) (Message, ResponseInterceptor, string, string, error) {
+func (myi *MyInterceptor) InterceptClientToMongo(m Message) (
+	Message,
+	ResponseInterceptor,
+	string,
+	address.Address,
+	error,
+	) {
 	switch mm := m.(type) {
 	case *QueryMessage:
 		if !NamespaceIsCommand(mm.Namespace) {

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -32,7 +32,6 @@ func insertDummyDocs(client *mongo.Client, numOfDocs int, ctx context.Context) e
 	if _, err := coll.InsertMany(ctx, docs); err != nil {
 		return fmt.Errorf("initial insert failed. err: %v", err)
 	}
-	fmt.Println("inserted", numOfDocs, "dummy docs")
 	return nil
 }
 

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -32,6 +32,7 @@ func insertDummyDocs(client *mongo.Client, numOfDocs int, ctx context.Context) e
 	if _, err := coll.InsertMany(ctx, docs); err != nil {
 		return fmt.Errorf("initial insert failed. err: %v", err)
 	}
+	fmt.Println("inserted", numOfDocs, "dummy docs")
 	return nil
 }
 
@@ -51,43 +52,33 @@ type MyFactory struct {
 }
 
 func (myf *MyFactory) NewInterceptor(ps *ProxySession) (ProxyInterceptor, error) {
-	return &MyInterceptor{ps, myf.mode, myf.mongoPort, myf.proxyPort, myf.disableIsMaster, myf.blockCommands}, nil
+	return &MyInterceptor{ps, myf.mode, myf.mongoPort, myf.proxyPort, myf.disableIsMaster, myf.blockCommands, NewLightCursorManager()}, nil
 }
 
-type SimulateRetryFixer struct {
+type FindFixer struct {
 	OriginalMessage Message
+	simulateRetry   bool
+	cm              *LightCursorManager
 }
 
-func (srf *SimulateRetryFixer) InterceptMongoToClient(m Message, _ address.Address) (Message, error) {
+func (ff *FindFixer) InterceptMongoToClient(m Message, address address.Address) (Message, error) {
 	switch mm := m.(type) {
 	case *MessageMessage:
-		var err error
-		var bodySection *BodySection = nil
-		for _, section := range mm.Sections {
-			if bs, ok := section.(*BodySection); ok {
-				if bodySection != nil {
-					return mm, NewStackErrorf("OP_MSG should not have more than one body section!  Second body section: %v", bs)
-				}
-				bodySection = bs
-			} else {
-				// MongoDB 3.6 does not support anything other than body sections in replies
-				return mm, NewStackErrorf("OP_MSG replies with sections other than a body section are not supported!")
-			}
-		}
-
-		if bodySection == nil {
-			return mm, NewStackErrorf("OP_MSG should have a body section!")
-		}
-		doc, err := bodySection.Body.ToBSOND()
+		doc, _, err := MessageMessageToBSOND(mm)
 		if err != nil {
-			return mm, err
+			return mm, NewStackErrorf("failed to get BSON.D from OP_MSG. err=%v", err)
 		}
-		val := BSONGetValueByNestedPathForTests(doc, "cursor.firstBatch.val", 0)
-		if v, ok := val.(int32); ok {
-			fmt.Println("SimulateRetryFixer::got ", v)
-			// trigger a retry error only if the server responds with a particular value
-			if v == util.RetryOnRemoteVal {
-				return mm, NewProxyRetryError(srf.OriginalMessage, util.RemoteRsName)
+		cidRaw := BSONGetValueByNestedPathForTests(doc, "cursor.id", 0)
+		if cid, ok := cidRaw.(int64); ok && cid > 0 {
+			ff.cm.Store(cid, address)
+		}
+		if ff.simulateRetry {
+			val := BSONGetValueByNestedPathForTests(doc, "cursor.firstBatch.val", 0)
+			if v, ok := val.(int32); ok {
+				// trigger a retry error only if the server responds with a particular value
+				if v == util.RetryOnRemoteVal {
+					return mm, NewProxyRetryError(ff.OriginalMessage, util.RemoteRsName)
+				}
 			}
 		}
 		return mm, nil
@@ -160,7 +151,7 @@ func fixIsMasterDirect(doc bson.D, mongoPort, proxyPort int) (SimpleBSON, error)
 	return SimpleBSONConvert(doc)
 }
 
-func (mri *IsMasterFixer) InterceptMongoToClient(m Message, _ address.Address) (Message, error) {
+func (mri *IsMasterFixer) InterceptMongoToClient(m Message, address address.Address) (Message, error) {
 	switch mm := m.(type) {
 	case *ReplyMessage:
 		var err error
@@ -223,6 +214,7 @@ type MyInterceptor struct {
 	proxyPort                int
 	disableStreamingIsMaster bool
 	blockCommands            map[string]time.Duration
+	cursorManager            *LightCursorManager
 }
 
 func (myi *MyInterceptor) GetClientMessage() Message {
@@ -290,23 +282,9 @@ func (myi *MyInterceptor) InterceptClientToMongo(m Message) (
 		mm.Query = qb
 		return mm, &IsMasterFixer{myi.mode, myi.mongoPort, myi.proxyPort}, "", "", nil
 	case *MessageMessage:
-		var err error
-		var bodySection *BodySection = nil
-		for _, section := range mm.Sections {
-			if bs, ok := section.(*BodySection); ok {
-				if bodySection != nil {
-					return mm, nil, "", "", NewStackErrorf("OP_MSG should not have more than one body section!  Second body section: %v", bs)
-				}
-				bodySection = bs
-			}
-		}
-
-		if bodySection == nil {
-			return mm, nil, "", "", NewStackErrorf("OP_MSG should have a body section!")
-		}
-		doc, err := bodySection.Body.ToBSOND()
+		doc, bodySection, err := MessageMessageToBSOND(mm)
 		if err != nil {
-			return mm, nil, "", "", err
+			panic(err)
 		}
 		var rsName string
 		var db string
@@ -351,9 +329,16 @@ func (myi *MyInterceptor) InterceptClientToMongo(m Message) (
 			return mm, &IsMasterFixer{myi.mode, myi.mongoPort, myi.proxyPort}, rsName, "", nil
 		case "find":
 			if db == util.RetryOnRemoteDbNameForTests {
-				return mm, &SimulateRetryFixer{mm}, "", "", nil
+				return mm, &FindFixer{mm, true, myi.cursorManager}, "", "", nil
 			}
-			return mm, nil, rsName, "", nil
+			return mm, &FindFixer{mm, false, myi.cursorManager}, rsName, "", nil
+		case "getmore":
+			cid, ok := doc[0].Value.(int64)
+			if !ok {
+				panic(fmt.Sprintf("got %T for cursor id but expected int64", cid))
+			}
+			addr, _ := myi.cursorManager.Load(cid)
+			return mm, nil, rsName, addr, nil
 		default:
 			return mm, nil, rsName, "", nil
 		}

--- a/inttests/lightcursormanager.go
+++ b/inttests/lightcursormanager.go
@@ -1,0 +1,36 @@
+package inttests
+
+import (
+	"sync"
+
+	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
+)
+
+/*
+	not bothering with clearing cursors since this is used for sanity tests only
+*/
+
+type LightCursorManager struct {
+	m    map[int64]address.Address
+	lock sync.RWMutex
+}
+
+func NewLightCursorManager() *LightCursorManager {
+	return &LightCursorManager{
+		make(map[int64]address.Address),
+		sync.RWMutex{},
+	}
+}
+
+func (cm *LightCursorManager) Store(cid int64, address address.Address) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+	cm.m[cid] = address
+}
+
+func (cm *LightCursorManager) Load(cid int64) (address.Address, bool) {
+	cm.lock.RLock()
+	defer cm.lock.RUnlock()
+	v, ok := cm.m[cid]
+	return v, ok
+}

--- a/inttests/pinnedServer_test.go
+++ b/inttests/pinnedServer_test.go
@@ -14,15 +14,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
-type CursorRes struct {
-	Id int64  `bson:"id"`
-	Ns string `bson:"ns"`
-}
-
-type FindRes struct {
-	Cursor CursorRes `bson:"cursor"`
-}
-
 func TestPinnedServer(t *testing.T) {
 	mongoPort, proxyPort, hostname := util.GetTestHostAndPorts()
 	pc := getProxyConfig(hostname, mongoPort, proxyPort, DefaultMaxPoolSize, DefaultMaxPoolIdleTimeSec, util.Cluster, false, nil)

--- a/inttests/pinnedServer_test.go
+++ b/inttests/pinnedServer_test.go
@@ -1,0 +1,79 @@
+package inttests
+
+import (
+	"testing"
+	"time"
+
+	"context"
+
+	. "github.com/mongodb/mongonet"
+	"github.com/mongodb/mongonet/util"
+	"github.com/mongodb/slogger/v2/slogger"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+type CursorRes struct {
+	Id int64  `bson:"id"`
+	Ns string `bson:"ns"`
+}
+
+type FindRes struct {
+	Cursor CursorRes `bson:"cursor"`
+}
+
+func TestPinnedServer(t *testing.T) {
+	mongoPort, proxyPort, hostname := util.GetTestHostAndPorts()
+	pc := getProxyConfig(hostname, mongoPort, proxyPort, DefaultMaxPoolSize, DefaultMaxPoolIdleTimeSec, util.Cluster, false, nil)
+	pc.LogLevel = slogger.DEBUG
+	proxy, err := NewProxy(pc)
+	if err != nil {
+		panic(err)
+	}
+	proxy.InitializeServer()
+	if ok, _, _ := proxy.OnSSLConfig(nil); !ok {
+		panic("failed to call OnSSLConfig")
+	}
+	go proxy.Run()
+
+	goctx := context.Background()
+	// insert some docs
+	client, err := util.GetTestClient(hostname, mongoPort, util.Cluster, false, "test", goctx)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Disconnect(goctx)
+	if err = insertDummyDocs(client, 100, goctx); err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup(client, goctx)
+	time.Sleep(time.Second) // let data replicate
+
+	proxyClient, err := util.GetTestClient(hostname, proxyPort, util.Cluster, false, "testProxy1", goctx)
+	if err != nil {
+		panic(err)
+	}
+	defer proxyClient.Disconnect(goctx)
+
+	dbSec := proxyClient.Database("test2")
+	cur, err := dbSec.Collection("foo", options.Collection().SetReadPreference(readpref.Secondary())).Find(goctx, bson.D{}, options.Find().SetBatchSize(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	docsFound := 0
+	i := cur.RemainingBatchLength()
+	for i > 0 {
+		cur.Next(goctx)
+		i--
+		docsFound++
+
+	}
+	// perform a getMore
+	for cur.Next(goctx) {
+		docsFound++
+	}
+	if docsFound != 100 {
+		t.Fatalf("expected to find 100 docs but found %v", docsFound)
+	}
+}

--- a/inttests/pinnedServer_test.go
+++ b/inttests/pinnedServer_test.go
@@ -52,6 +52,7 @@ func TestPinnedServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cur.Close(goctx)
 	docsFound := 0
 	i := cur.RemainingBatchLength()
 	for i > 0 {

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -46,7 +46,7 @@ type MetricsHookFactory interface {
 }
 
 type ResponseInterceptor interface {
-	InterceptMongoToClient(m Message) (Message, error)
+	InterceptMongoToClient(m Message, serverAddress address.Address) (Message, error)
 }
 
 type ProxyInterceptor interface {
@@ -510,7 +510,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 			}
 		}
 		if respInter != nil {
-			resp, err = respInter.InterceptMongoToClient(resp)
+			resp, err = respInter.InterceptMongoToClient(resp, mongoConn.conn.Address())
 			if err != nil {
 				if ps.isMetricsEnabled {
 					hookErr := responseErrorsHook.IncCounterGauge()

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -286,7 +286,7 @@ func (ps *ProxySession) getMongoConnection(
 	rp *readpref.ReadPref,
 	topology *topology.Topology,
 	pinnedAddress address.Address,
-	) (*MongoConnectionWrapper, error) {
+) (*MongoConnectionWrapper, error) {
 	ps.logTrace(ps.proxy.logger, ps.proxy.Config.TraceConnPool, "finding a server")
 	var srvSelector description.ServerSelector
 

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -137,7 +137,6 @@ func (ps *ProxySession) respondWithError(clientMessage Message, err error) error
 			0, // StartingFrom
 			1, // NumberReturned
 			[]SimpleBSON{doc},
-			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, ps.conn)
 
@@ -167,7 +166,6 @@ func (ps *ProxySession) respondWithError(clientMessage Message, err error) error
 					doc,
 				},
 			},
-			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, ps.conn)
 
@@ -193,7 +191,7 @@ func logPanic(logger *slogger.Logger) {
 }
 
 func getReadPrefFromOpMsg(mm *MessageMessage, logger *slogger.Logger, defaultRp *readpref.ReadPref) (rp *readpref.ReadPref, err error) {
-	rpVal, err2 := mm.BodyDoc.LookupErr("$readPreference")
+	rpVal, err2 := mm.BodyDoc().LookupErr("$readPreference")
 	if err2 != nil {
 		if err2 == bsoncore.ErrElementNotFound {
 			return defaultRp, nil
@@ -487,7 +485,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 		}
 		switch mm := resp.(type) {
 		case *MessageMessage:
-			if err := extractError(mm.BodyDoc); err != nil {
+			if err := extractError(mm.BodyDoc()); err != nil {
 				if ps.isMetricsEnabled {
 					hookErr := responseErrorsHook.IncCounterGauge()
 					if hookErr != nil {

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -498,7 +498,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper) (*MongoConnect
 				mongoConn.ep.ProcessError(err, mongoConn.conn)
 			}
 		case *ReplyMessage:
-			if err := extractError(mm.CommandDoc); err != nil {
+			if err := extractError(mm.CommandDoc()); err != nil {
 				if ps.isMetricsEnabled {
 					hookErr := responseErrorsHook.IncCounterGauge()
 					if hookErr != nil {

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -292,7 +292,7 @@ func (ps *ProxySession) getMongoConnection(
 	topology *topology.Topology,
 	pinnedAddress address.Address,
 ) (*MongoConnectionWrapper, error) {
-	ps.logTrace(ps.proxy.logger, ps.proxy.Config.TraceConnPool, "finding a server")
+	ps.logTrace(ps.proxy.logger, ps.proxy.Config.TraceConnPool, "finding a server. readpref=%v, pinnedAddress=%v", rp, pinnedAddress)
 	var srvSelector description.ServerSelector
 
 	switch {

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -296,13 +296,10 @@ func (ps *ProxySession) getMongoConnection(
 	var srvSelector description.ServerSelector
 
 	switch {
-
 	case len(pinnedAddress.String()) > 0:
 		srvSelector = PinnedServerSelector(pinnedAddress)
-
 	case ps.proxy.Config.ConnectionMode == util.Cluster:
 		srvSelector = description.ReadPrefSelector(rp)
-
 	default:
 		// Direct
 		srvSelector = PinnedServerSelector(address.Address(ps.proxy.Config.MongoAddress()))

--- a/session.go
+++ b/session.go
@@ -140,7 +140,6 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 			0, // StartingFrom
 			1, // NumberReturned
 			[]SimpleBSON{doc},
-			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 
@@ -174,7 +173,6 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 					doc,
 				},
 			},
-			bsoncore.Document(doc.BSON),
 		}
 		return SendMessage(rm, s.conn)
 
@@ -187,7 +185,7 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 
 }
 
-func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, queryFailureErr error, cursorID int64, docs []SimpleBSON) error {
+func (s *Session) RespondToGetMore(clientMessage Message, cursorFound bool, queryFailureErr error, cursorID int64, docs []SimpleBSON) error {
 	if clientMessage.Header().OpCode != OP_GET_MORE {
 		return errors.New("Internal error")
 	}

--- a/session.go
+++ b/session.go
@@ -192,7 +192,7 @@ func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, isQueryFa
 		return errors.New("Internal error")
 	}
 
-	flags := 0
+	var flags int32 = 0
 	if !cursorFound {
 		flags |= 1 // 1st bit set indicates cursor not found
 		cursorID = 0
@@ -203,7 +203,7 @@ func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, isQueryFa
 	if isQueryFailure {
 		flags |= 2
 		if len(docs) > 0 {
-			commandDoc = bsoncore.Document(docs[0])
+			commandDoc = bsoncore.Document(docs[0].BSON)
 		}
 	}
 
@@ -217,7 +217,7 @@ func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, isQueryFa
 		flags,
 		cursorID,
 		0, // unused
-		len(docs),
+		int32(len(docs)),
 		docs,
 		commandDoc,
 	}

--- a/session.go
+++ b/session.go
@@ -187,7 +187,7 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 
 }
 
-func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, isQueryFailure bool, cursorID int64, docs []SimpleBSON) error {
+func (s *Session) RespondToGetMore(clientMessage Message, cursorFound, queryFailureErr error, cursorID int64, docs []SimpleBSON) error {
 	if clientMessage.Header().OpCode != OP_GET_MORE {
 		return errors.New("Internal error")
 	}

--- a/session.go
+++ b/session.go
@@ -193,10 +193,11 @@ func (s *Session) RespondToGetMore(clientMessage Message, cursorFound bool, quer
 	if !cursorFound {
 		flags |= 1 // 1st bit set indicates cursor not found
 		cursorID = 0
+		docs = []SimpleBSON{}
 	}
 
 	if queryFailureErr != nil {
-		flags |= 2
+		flags |= 2 // 2nd bit indicates query failure
 		if docs == nil || len(docs) == 0 {
 			doc, err := SimpleBSONConvert(bson.D{{"$err", queryFailureErr.Error()}})
 			if err != nil {

--- a/session.go
+++ b/session.go
@@ -124,7 +124,7 @@ func (s *Session) RespondToCommandMakeBSON(clientMessage Message, args ...interf
 	return s.RespondToCommand(clientMessage, doc2)
 }
 
-// do not call with OP_GET_MORE
+// do not call with OP_GET_MORE since we never added support for that
 func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error {
 	switch clientMessage.Header().OpCode {
 

--- a/session.go
+++ b/session.go
@@ -124,6 +124,7 @@ func (s *Session) RespondToCommandMakeBSON(clientMessage Message, args ...interf
 	return s.RespondToCommand(clientMessage, doc2)
 }
 
+// do not call with OP_GET_MORE
 func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error {
 	switch clientMessage.Header().OpCode {
 
@@ -176,7 +177,7 @@ func (s *Session) RespondToCommand(clientMessage Message, doc SimpleBSON) error 
 		return SendMessage(rm, s.conn)
 
 	case OP_GET_MORE:
-		return errors.New("Internal error")
+		return errors.New("Internal error.  Should not be passing a GET_MORE message here.")
 
 	default:
 		return ErrUnknownOpcode

--- a/util.go
+++ b/util.go
@@ -62,6 +62,10 @@ func stripDirectories(filepath string, toKeep int) string {
 }
 
 func extractError(rdr bsoncore.Document) error {
+	if rdr == nil {
+		return nil
+	}
+
 	var errmsg, codeName string
 	var code int32
 	var labels []string

--- a/wire.go
+++ b/wire.go
@@ -53,7 +53,7 @@ type ReplyMessage struct {
 	StartingFrom   int32
 	NumberReturned int32
 
-	Docs       []SimpleBSON
+	Docs []SimpleBSON
 }
 
 func (rm *ReplyMessage) CommandDoc() bsoncore.Document {

--- a/wire.go
+++ b/wire.go
@@ -152,9 +152,16 @@ type MessageMessage struct {
 
 	FlagBits int32
 	Sections []MessageMessageSection
-	BodyDoc  bsoncore.Document
 }
 
 func (mm *MessageMessage) BodyDoc() bsoncore.Document {
-	for _, sec := 
+	// when parsed in in parseMessageMessage we checked that there was exactly one BodySection
+	// as such we can stop as soon as we find it
+	for _, sec := range mm.Sections {
+		if bodySection, ok := sec.(*BodySection); ok && bodySection != nil {
+			return bsoncore.Document(bodySection.Body.BSON)
+		}
+	}
+
+	panic(fmt.Errorf("unreachable"))
 }

--- a/wire.go
+++ b/wire.go
@@ -158,14 +158,14 @@ type MessageMessage struct {
 	Sections []MessageMessageSection
 }
 
-func (mm *MessageMessage) BodyDoc() bsoncore.Document {
+func (mm *MessageMessage) BodyDoc() (bsoncore.Document, error) {
 	// when parsed in in parseMessageMessage we checked that there was exactly one BodySection
 	// as such we can stop as soon as we find it
 	for _, sec := range mm.Sections {
 		if bodySection, ok := sec.(*BodySection); ok && bodySection != nil {
-			return bsoncore.Document(bodySection.Body.BSON)
+			return bsoncore.Document(bodySection.Body.BSON), nil
 		}
 	}
 
-	panic(fmt.Errorf("unreachable"))
+	return nil, fmt.Errorf("no body section found for OP_MSG")
 }

--- a/wire.go
+++ b/wire.go
@@ -50,7 +50,14 @@ type ReplyMessage struct {
 	NumberReturned int32
 
 	Docs       []SimpleBSON
-	CommandDoc bsoncore.Document
+}
+
+func (rm *ReplyMessage) CommandDoc() bsoncore.Document {
+	if len(rm.Docs) == 0 {
+		return nil
+	}
+
+	return bsoncore.Document(rm.Docs[0].BSON)
 }
 
 // OP_UPDATE
@@ -146,4 +153,8 @@ type MessageMessage struct {
 	FlagBits int32
 	Sections []MessageMessageSection
 	BodyDoc  bsoncore.Document
+}
+
+func (mm *MessageMessage) BodyDoc() bsoncore.Document {
+	for _, sec := 
 }

--- a/wire.go
+++ b/wire.go
@@ -1,6 +1,10 @@
 package mongonet
 
-import "go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+
+	"fmt"
+)
 
 const (
 	OP_REPLY         = 1

--- a/wire_reply.go
+++ b/wire_reply.go
@@ -1,7 +1,5 @@
 package mongonet
 
-import "go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
-
 func (m *ReplyMessage) HasResponse() bool {
 	return false // because its a response
 }
@@ -67,8 +65,6 @@ func parseReplyMessage(header MessageHeader, buf []byte) (Message, error) {
 		rm.Docs = append(rm.Docs, doc)
 		loc += int(doc.Size)
 	}
-	if len(rm.Docs) > 0 {
-		rm.CommandDoc = bsoncore.Document(rm.Docs[0].BSON)
-	}
+
 	return rm, nil
 }


### PR DESCRIPTION
This adds support to mongonet for helping clients to associate a cursor with a particular server.

Louisa, I am assigning to you for now because Tomer is out until Sunday.  If we don't need this merged until next week then we can add Tomer as a reviewer.