### PR TITLE
Support Proxy Protocol

### DIFF
--- a/connwrapper.go
+++ b/connwrapper.go
@@ -104,9 +104,8 @@ func (c *Conn) Write(p []byte) (int, error) {
 
 func (c *Conn) init() error {
 	c.remote = c.wrapped.RemoteAddr()
-
 	// check if the first byte is one of our recognized signatures
-	if b1, err := c.rbuf.Peek(1); err == nil && (b1[0] == v1Signature[0] || b1[0] == v2Signature[0]) {
+	if b1, err := c.rbuf.Peek(1); err == nil && b1[0] == v1Signature[0] || b1[0] == v2Signature[0] {
 		if sig, err := c.rbuf.Peek(5); err == nil && bytes.Equal(sig, v1Signature) {
 			return c.initv1()
 		}

--- a/connwrapper.go
+++ b/connwrapper.go
@@ -108,7 +108,7 @@ func (c *Conn) init() error {
 	}
 	c.remote = c.wrapped.RemoteAddr()
 	// check if the first byte is one of our recognized signatures
-	if b1, err := c.rbuf.Peek(1); err == nil && b1[0] == v1Signature[0] || b1[0] == v2Signature[0] {
+	if b1, err := c.rbuf.Peek(1); err == nil && len(b1) > 0 && (b1[0] == v1Signature[0] || b1[0] == v2Signature[0]) {
 		if sig, err := c.rbuf.Peek(5); err == nil && bytes.Equal(sig, v1Signature) {
 			return c.initv1()
 		}

--- a/connwrapper.go
+++ b/connwrapper.go
@@ -103,6 +103,9 @@ func (c *Conn) Write(p []byte) (int, error) {
 }
 
 func (c *Conn) init() error {
+	if c.wrapped == nil {
+		return fmt.Errorf("init a nil connection")
+	}
 	c.remote = c.wrapped.RemoteAddr()
 	// check if the first byte is one of our recognized signatures
 	if b1, err := c.rbuf.Peek(1); err == nil && b1[0] == v1Signature[0] || b1[0] == v2Signature[0] {

--- a/connwrapper.go
+++ b/connwrapper.go
@@ -1,0 +1,334 @@
+package mongonet
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	v1Signature = []byte{0x50, 0x52, 0x4F, 0x58, 0x59}
+	v2Signature = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+)
+
+type Conn struct {
+	wrapped net.Conn
+	rbuf    *bufio.Reader
+
+	version byte
+
+	proxy  net.Addr
+	remote net.Addr
+	target net.Addr
+}
+
+func NewConn(wrapped net.Conn) (*Conn, error) {
+	c := &Conn{
+		wrapped: wrapped,
+		rbuf:    bufio.NewReader(wrapped),
+	}
+
+	if err := c.init(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Close implements the io.Closer interface.
+func (c *Conn) Close() error {
+	return c.wrapped.Close()
+}
+
+// IsProxied returns true if the PROXY PROTOCOL was used.
+func (c *Conn) IsProxied() bool {
+	return c.proxy != nil
+}
+
+// LocalAddr implements the net.Conn interface.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.wrapped.LocalAddr()
+}
+
+// ProxyAddr returns the proxy server's addr if IsProxied() is true; otherwise nil.
+func (c *Conn) ProxyAddr() net.Addr {
+	return c.proxy
+}
+
+// Read implements the io.Reader interface.
+func (c *Conn) Read(p []byte) (int, error) {
+	return c.rbuf.Read(p)
+}
+
+// RemoteAddr implements the net.Conn interface.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+// TargetAddr returns the client's intended target addr if IsProxied() is true; otherwise nil.
+func (c *Conn) TargetAddr() net.Addr {
+	return c.target
+}
+
+// SetDeadline implements the net.Conn interface.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.wrapped.SetDeadline(t)
+}
+
+// SetReadDeadline implements the net.Conn interface.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.wrapped.SetReadDeadline(t)
+}
+
+// SetWriteDeadline implements the net.Conn interface.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.wrapped.SetWriteDeadline(t)
+}
+
+// Version returns the version of the PROXY PROTOCOL.
+func (c *Conn) Version() byte {
+	return c.version
+}
+
+// Write implements the io.Writer interface.
+func (c *Conn) Write(p []byte) (int, error) {
+	return c.wrapped.Write(p)
+}
+
+func (c *Conn) init() error {
+	c.remote = c.wrapped.RemoteAddr()
+
+	// check if the first byte is one of our recognized signatures
+	if b1, err := c.rbuf.Peek(1); err == nil && (b1[0] == v1Signature[0] || b1[0] == v2Signature[0]) {
+		if sig, err := c.rbuf.Peek(5); err == nil && bytes.Equal(sig, v1Signature) {
+			return c.initv1()
+		}
+		if sig, err := c.rbuf.Peek(12); err == nil && bytes.Equal(sig, v2Signature) {
+			return c.initv2()
+		}
+	}
+
+	// not a proxy connection
+	return nil
+}
+
+func (c *Conn) initv1() error {
+	c.version = 1
+	line, _ := c.rbuf.ReadString('\n')
+	if !strings.HasSuffix(line, "\r\n") {
+		return errors.New("invalid header")
+	}
+
+	parts := strings.Split(line[:len(line)-2], " ")
+	if len(parts) < 6 {
+		if len(parts) > 1 && parts[1] == "UNKNOWN" {
+			return nil
+		}
+
+		return errors.New("invalid header")
+	}
+
+	var srcIP net.IP
+	var dstIP net.IP
+	switch parts[1] {
+	case "TCP4":
+
+		if srcIP = net.ParseIP(parts[2]).To4(); srcIP == nil {
+			return errors.New("invalid ip address")
+		}
+		if dstIP = net.ParseIP(parts[3]).To4(); dstIP == nil {
+			return errors.New("invalid ip address")
+		}
+
+	case "TCP6":
+
+		if srcIP = net.ParseIP(parts[2]).To16(); srcIP == nil {
+			return errors.New("invalid ip address")
+		}
+		if dstIP = net.ParseIP(parts[3]).To16(); dstIP == nil {
+			return errors.New("invalid ip address")
+		}
+	case "UNKNOWN":
+		return nil
+	default:
+		return errors.New("invalid protocol and family")
+	}
+
+	srcPort, err := parsePort(parts[4])
+	if err != nil {
+		return err
+	}
+
+	dstPort, err := parsePort(parts[5])
+	if err != nil {
+		return err
+	}
+
+	c.remote = &net.TCPAddr{
+		IP:   srcIP,
+		Port: srcPort,
+	}
+
+	c.target = &net.TCPAddr{
+		IP:   dstIP,
+		Port: dstPort,
+	}
+
+	c.proxy = c.wrapped.RemoteAddr()
+	return nil
+}
+
+func (c *Conn) initv2() error {
+	header := make([]byte, 16)
+	_, err := io.ReadFull(c.rbuf, header)
+	if err != nil {
+		return fmt.Errorf("failed reading header: %w", err)
+	}
+
+	if !bytes.Equal(header[:12], v2Signature) {
+		return errors.New("v2 header does not match signature")
+	}
+
+	vac := versionAndCommand(header[12])
+	if vac.Version() != 2 {
+		return errors.New("invalid version")
+	} else if vac.Command() != local && vac.Command() != proxy {
+		return errors.New("invalid command")
+	}
+
+	c.version = vac.Version()
+
+	addrProto := addressFamilyAndProtocol(header[13])
+	length := int64(binary.BigEndian.Uint16(header[14:16]))
+	payload := make([]byte, length)
+	_, err = io.ReadFull(c.rbuf, payload)
+	if err != nil {
+		return fmt.Errorf("failed reading payload: %w", err)
+	}
+
+	if vac.Command() == local {
+		// we can ignore everything else
+		return nil
+	}
+
+	var srcIP net.IP
+	var dstIP net.IP
+	var srcPort uint16
+	var dstPort uint16
+
+	switch addrProto.AddressFamily() {
+	case inet:
+		if len(payload) < 12 {
+			return errors.New("invalid IPv4 payload")
+		}
+
+		srcIP = net.IPv4(payload[0], payload[1], payload[2], payload[3])
+		dstIP = net.IPv4(payload[4], payload[5], payload[6], payload[7])
+		srcPort = binary.BigEndian.Uint16(payload[8:10])
+		dstPort = binary.BigEndian.Uint16(payload[10:12])
+	case inet6:
+		if len(payload) < 36 {
+			return errors.New("invalid IPv6 payload")
+		}
+
+		srcIP = net.IP(payload[:16])
+		dstIP = net.IP(payload[16:32])
+		srcPort = binary.BigEndian.Uint16(payload[32:34])
+		dstPort = binary.BigEndian.Uint16(payload[34:36])
+	case unix:
+		return errors.New("unix sockets are not supported")
+	case unspec:
+		// ignore
+	default:
+		return errors.New("invalid address family")
+	}
+
+	switch addrProto.Protocol() {
+	case stream:
+		c.remote = &net.TCPAddr{
+			IP:   srcIP,
+			Port: int(srcPort),
+		}
+
+		c.target = &net.TCPAddr{
+			IP:   dstIP,
+			Port: int(dstPort),
+		}
+	case datagram:
+		c.remote = &net.UDPAddr{
+			IP:   srcIP,
+			Port: int(srcPort),
+		}
+
+		c.target = &net.UDPAddr{
+			IP:   dstIP,
+			Port: int(dstPort),
+		}
+	default:
+		if addrProto.AddressFamily() != unspec {
+			return errors.New("invalid protocol")
+		}
+	}
+
+	c.proxy = c.wrapped.RemoteAddr()
+	return nil
+}
+
+type addressFamilyAndProtocol byte
+
+type addressFamily byte
+type protocol byte
+
+const (
+	unspec addressFamily = iota
+	inet
+	inet6
+	unix
+)
+
+const (
+	stream protocol = iota + 1
+	datagram
+)
+
+func (ap addressFamilyAndProtocol) AddressFamily() addressFamily {
+	return addressFamily(ap >> 4)
+}
+
+func (ap addressFamilyAndProtocol) Protocol() protocol {
+	return protocol(ap & 0x0F)
+}
+
+type versionAndCommand byte
+
+type command byte
+
+// Command constants.
+const (
+	local command = iota
+	proxy
+)
+
+func (vac versionAndCommand) Version() byte {
+	return byte(vac >> 4)
+}
+
+func (vac versionAndCommand) Command() command {
+	return command(vac & 0x0F)
+}
+
+func parsePort(s string) (int, error) {
+	port, err := strconv.Atoi(s)
+	if err != nil || port < 0 || port > 65535 {
+		return 0, errors.New("invalid port number")
+	}
+
+	return port, nil
+}

--- a/connwrapper_test.go
+++ b/connwrapper_test.go
@@ -57,7 +57,6 @@ func TestProxyProtocol(t *testing.T) {
 		}
 	)
 
-	t.Parallel()
 	testCases := []struct {
 		name               string
 		bytes              []byte
@@ -351,8 +350,6 @@ func TestProxyProtocol(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			c := newMockConn(tc.bytes)
 			subject, err := NewConn(c)
 			if err != nil && tc.expectedErr == nil {

--- a/connwrapper_test.go
+++ b/connwrapper_test.go
@@ -1,0 +1,443 @@
+package mongonet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestProxyProtocol(t *testing.T) {
+
+	var (
+		v2SignatureBytes = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+
+		// version/command.
+		localBytes = []byte{0x20}
+		proxyBytes = []byte{0x21}
+
+		// address family and protocol
+		tcpV4Bytes = []byte{0x11}
+		udpV4Bytes = []byte{0x12}
+		tcpV6Bytes = []byte{0x21}
+		udpV6Bytes = []byte{0x22}
+
+		// addresses
+		localIPv4                 = net.ParseIP("127.0.0.1").To4()
+		localIPv6                 = net.ParseIP("::1").To16()
+		remoteIPv4                = net.ParseIP("127.0.0.2").To4()
+		remoteIPv6                = net.ParseIP("::2").To16()
+		portBytes                 = []byte{0xFD, 0xE8, 0xFD, 0xE9}
+		v4AddressesBytes          = append(localIPv4, remoteIPv4...)
+		v6AddressesBytes          = append(localIPv6, remoteIPv6...)
+		v4AddressesWithPortsBytes = append(v4AddressesBytes, portBytes...)
+		v6AddressesWithPortsBytes = append(v6AddressesBytes, portBytes...)
+
+		// lengths
+		lengthV4          = uint16(12)
+		lengthV6          = uint16(36)
+		lengthPadded      = uint16(84)
+		lengthV4Bytes     = []byte{0x00, 0xC}
+		lengthV6Bytes     = []byte{0x00, 0x24}
+		lengthEmptyBytes  = []byte{0x00, 0x00}
+		lengthPaddedBytes = []byte{0x00, 0x54}
+
+		// message
+		messageBytes = []byte("MESSAGE")
+
+		// util
+		concat = func(parts ...[]byte) []byte {
+			var result []byte
+			for _, p := range parts {
+				result = append(result, p...)
+			}
+			return result
+		}
+	)
+
+	t.Parallel()
+	testCases := []struct {
+		name               string
+		bytes              []byte
+		expectedLocalAddr  string
+		expectedProxyAddr  string
+		expectedRemoteAddr string
+		expectedTargetAddr string
+		expectedErr        error
+	}{
+		{
+			"not proxy protocol",
+			messageBytes,
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v1-invalid header 1",
+			[]byte("PROXY"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid header"),
+		},
+		{
+			"v1-invalid header 2",
+			[]byte("PROXY \r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid header"),
+		},
+		{
+			"v1-invalid header 2",
+			[]byte("PROXY UDP4 127.0.0.1 127.0.0.2 65000 65001\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid protocol and family"),
+		},
+		{
+			"v1-invalid src ip address",
+			[]byte("PROXY TCP4 127.0 127.0.0.2 65000 65001\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid ip address"),
+		},
+		{
+			"v1-invalid dst ip address",
+			[]byte("PROXY TCP4 127.0.0.1 127.2 65000 65001\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid ip address"),
+		},
+		{
+			"v1-invalid src port",
+			[]byte("PROXY TCP4 127.0.0.1 127.0.0.2 70000 65001\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid port number"),
+		},
+		{
+			"v1-invalid dst port",
+			[]byte("PROXY TCP4 127.0.0.1 127.0.0.2 65000 abd\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid port number"),
+		},
+		{
+			"v1-unknown",
+			[]byte("PROXY UNKNOWN 127.0.0.1 127.0.0.2 65000 65001\r\nMESSAGE"),
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v1-unknown",
+			[]byte("PROXY UNKNOWN\r\nMESSAGE"),
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v1-tcp4",
+			[]byte("PROXY TCP4 127.0.0.1 127.0.0.2 65000 65001\r\nMESSAGE"),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"127.0.0.1:65000",
+			"127.0.0.2:65001",
+			nil,
+		},
+		{
+			"v1-tcp6",
+			[]byte("PROXY TCP6 ::1 ::2 65000 65001\r\nMESSAGE"),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"[::1]:65000",
+			"[::2]:65001",
+			nil,
+		},
+		{
+			"v2-invalid version",
+			concat(v2SignatureBytes, []byte{0x10}, tcpV4Bytes, lengthEmptyBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid version"),
+		},
+		{
+			"v2-invalid command",
+			concat(v2SignatureBytes, []byte{0x22}, tcpV4Bytes, lengthEmptyBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid command"),
+		},
+		{
+			"v2-invalid address family",
+			concat(v2SignatureBytes, proxyBytes, []byte{0x41}, lengthEmptyBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid address family"),
+		},
+		{
+			"v2-invalid protocol",
+			concat(v2SignatureBytes, proxyBytes, []byte{0x23}, lengthV6Bytes, v6AddressesWithPortsBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid protocol"),
+		},
+		{
+			"v2-invalid ipv4 length",
+			concat(v2SignatureBytes, proxyBytes, tcpV4Bytes, []byte{0x00, 0xB}, v4AddressesWithPortsBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid IPv4 payload"),
+		},
+		{
+			"v2-invalid ipv6 length",
+			concat(v2SignatureBytes, proxyBytes, tcpV6Bytes, []byte{0x00, 0xC}, v4AddressesWithPortsBytes, messageBytes),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid IPv6 payload"),
+		},
+		{
+			"v2-local",
+			concat(v2SignatureBytes, localBytes, tcpV4Bytes, lengthEmptyBytes, messageBytes),
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v2-local-tcp-ipv4 with extra bytes",
+			concat(v2SignatureBytes, localBytes, tcpV4Bytes, lengthPaddedBytes, v4AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV4), messageBytes),
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v2-local-tcp-ipv6 with extra bytes",
+			concat(v2SignatureBytes, localBytes, tcpV6Bytes, lengthPaddedBytes, v6AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV6), messageBytes),
+			"192.168.0.2:5001",
+			"",
+			"192.168.0.1:5000",
+			"",
+			nil,
+		},
+		{
+			"v2-proxy-tcp-ipv4",
+			concat(v2SignatureBytes, proxyBytes, tcpV4Bytes, lengthV4Bytes, v4AddressesWithPortsBytes, messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"127.0.0.1:65000",
+			"127.0.0.2:65001",
+			nil,
+		},
+		{
+			"v2-proxy-tcp-ipv4 with extra bytes",
+			concat(v2SignatureBytes, proxyBytes, tcpV4Bytes, lengthPaddedBytes, v4AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV4), messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"127.0.0.1:65000",
+			"127.0.0.2:65001",
+			nil,
+		},
+		{
+			"v2-proxy-tcp-ipv6",
+			concat(v2SignatureBytes, proxyBytes, tcpV6Bytes, lengthV6Bytes, v6AddressesWithPortsBytes, messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"[::1]:65000",
+			"[::2]:65001",
+			nil,
+		},
+		{
+			"v2-proxy-tcp-ipv6 with extra bytes",
+			concat(v2SignatureBytes, proxyBytes, tcpV6Bytes, lengthPaddedBytes, v6AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV6), messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"[::1]:65000",
+			"[::2]:65001",
+			nil,
+		},
+		{
+			"v2-proxy-udp-ipv4",
+			concat(v2SignatureBytes, proxyBytes, udpV4Bytes, lengthV4Bytes, v4AddressesWithPortsBytes, messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"127.0.0.1:65000",
+			"127.0.0.2:65001",
+			nil,
+		},
+		{
+			"v2-proxy-udp-ipv4 with extra bytes",
+			concat(v2SignatureBytes, proxyBytes, udpV4Bytes, lengthPaddedBytes, v4AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV4), messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"127.0.0.1:65000",
+			"127.0.0.2:65001",
+			nil,
+		},
+		{
+			"v2-proxy-udp-ipv6",
+			concat(v2SignatureBytes, proxyBytes, udpV6Bytes, lengthV6Bytes, v6AddressesWithPortsBytes, messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"[::1]:65000",
+			"[::2]:65001",
+			nil,
+		},
+		{
+			"v2-proxy-udp-ipv6 with extra bytes",
+			concat(v2SignatureBytes, proxyBytes, udpV6Bytes, lengthPaddedBytes, v6AddressesWithPortsBytes, make([]byte, lengthPadded-lengthV6), messageBytes),
+			"192.168.0.2:5001",
+			"192.168.0.1:5000",
+			"[::1]:65000",
+			"[::2]:65001",
+			nil,
+		},
+		{
+			"unix sockets",
+			[]byte("\r\n\r\n\x00\r\nQUIT\n!0\x00\x00"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("unix sockets are not supported"),
+		},
+		{
+			"not enough data",
+			[]byte("PROXY\r\n"),
+			"",
+			"",
+			"",
+			"",
+			errors.New("invalid header"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newMockConn(tc.bytes)
+			subject, err := NewConn(c)
+			if err != nil && tc.expectedErr == nil {
+				t.Fatalf("expected no error, but got %v", err)
+			} else if err == nil && tc.expectedErr != nil {
+				t.Fatalf("expected error %v, but got none", tc.expectedErr)
+			} else if err != nil && tc.expectedErr != nil {
+				if err.Error() != tc.expectedErr.Error() {
+					t.Fatalf("expected error %v, but got %v", tc.expectedErr, err)
+				}
+				return // we are successful
+			}
+
+			if tc.expectedLocalAddr != subject.LocalAddr().String() {
+				t.Fatalf("expected local address %v, but got %v", tc.expectedLocalAddr, subject.LocalAddr())
+			}
+
+			if subject.IsProxied() && tc.expectedProxyAddr != subject.ProxyAddr().String() {
+				t.Fatalf("expected proxy address %v, but got %v", tc.expectedProxyAddr, subject.ProxyAddr())
+			}
+
+			if tc.expectedRemoteAddr != subject.RemoteAddr().String() {
+				t.Fatalf("expected remote address %v, but got %v", tc.expectedRemoteAddr, subject.RemoteAddr())
+			}
+
+			if subject.IsProxied() && tc.expectedTargetAddr != subject.TargetAddr().String() {
+				t.Fatalf("expected target address %v, but got %v", tc.expectedTargetAddr, subject.TargetAddr())
+			}
+
+			actualMessageBytes := make([]byte, len(messageBytes))
+			_, err = io.ReadFull(subject, actualMessageBytes)
+			if err != nil {
+				t.Fatalf("expected no error, but got %v", err)
+			}
+			if !bytes.Equal(messageBytes, actualMessageBytes) {
+				t.Fatalf("expected message %v, but got %v", messageBytes, actualMessageBytes)
+			}
+		})
+	}
+}
+
+func newMockConn(b []byte) *mockConn {
+	return &mockConn{
+		r: bytes.NewReader(b),
+	}
+}
+
+type mockConn struct {
+	r *bytes.Reader
+}
+
+func (c *mockConn) Close() error {
+	return nil
+}
+
+func (c *mockConn) Read(b []byte) (n int, err error) {
+	return c.r.Read(b)
+}
+
+func (c *mockConn) Write(b []byte) (n int, err error) {
+	panic("don't call me")
+}
+
+func (c *mockConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("192.168.0.2"),
+		Port: 5001,
+	}
+}
+
+func (c *mockConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.ParseIP("192.168.0.1"),
+		Port: 5000,
+	}
+}
+
+func (c *mockConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *mockConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *mockConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/inttests/haproxy.conf
+++ b/inttests/haproxy.conf
@@ -1,0 +1,17 @@
+frontend proxyv1
+    bind 127.0.0.1:9915
+    mode tcp
+    use_backend mongonetv1
+
+backend mongonetv1
+    mode tcp
+    server mongonet_server 127.0.0.1:9917 check send-proxy
+
+frontend proxyv2
+    bind 127.0.0.1:9916
+    mode tcp
+    use_backend mongonetv2
+
+backend mongonetv2
+    mode tcp
+    server mongonet_server 127.0.0.1:9917 check send-proxy-v2

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -330,6 +330,10 @@ func (myi *MyInterceptor) InterceptClientToMongo(m Message, previousResult Simpl
 			}
 			addr, _ := myi.cursorManager.Load(cid)
 			return mm, nil, rsName, addr, nil
+		case "mongonetisconnectionproxied":
+			// test command
+			return nil, nil, "", "", myi.ps.RespondToCommandMakeBSON(mm, "proxied", myi.ps.IsProxied())
+
 		default:
 			return mm, nil, rsName, "", nil
 		}

--- a/inttests/multiple_proxies_test.go
+++ b/inttests/multiple_proxies_test.go
@@ -1,0 +1,63 @@
+package inttests
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/mongodb/mongonet"
+	"github.com/mongodb/mongonet/util"
+	"github.com/mongodb/slogger/v2/slogger"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+/*
+	This test requires a HAProxy running and forwarding TCP traffic to the proxy (using haproxy.conf)
+	connection reset by peer errors might appear due to HAProxy health checks
+*/
+
+func TestCommonProxyProtocolInt(t *testing.T) {
+	type mongonetIsConnectionProxiedResponse struct {
+		Proxied bool `bson:"proxied"`
+	}
+	mongoPort, _, hostname := util.GetTestHostAndPorts()
+	proxyPort := 9917 // fixed for HAProxy config
+	haProxyPortV1 := 9915
+	haProxyPortV2 := 9916
+	pc := getProxyConfig(hostname, mongoPort, proxyPort, DefaultMaxPoolSize, DefaultMaxPoolIdleTimeSec, util.Cluster, false, nil)
+	pc.LogLevel = slogger.DEBUG
+	proxy, err := NewProxy(pc)
+	if err != nil {
+		panic(err)
+	}
+	proxy.InitializeServer()
+	if ok, _, _ := proxy.OnSSLConfig(nil); !ok {
+		panic("failed to call OnSSLConfig")
+	}
+	go proxy.Run()
+
+	goctx := context.Background()
+
+	check := func(name string, port int, expected bool) {
+		proxyClient, err := util.GetTestClient(hostname, port, util.Cluster, false, "testProxy1", goctx)
+		if err != nil {
+			t.Fatalf("%s:%v", name, err)
+		}
+		defer proxyClient.Disconnect(goctx)
+		var response mongonetIsConnectionProxiedResponse
+		res := proxyClient.Database("admin").RunCommand(goctx, bson.D{{"mongonetIsConnectionProxied", ""}})
+		if res.Err() != nil {
+			t.Fatalf("%s:%v", name, res.Err())
+		}
+		if err := res.Decode(&response); err != nil {
+			t.Fatalf("%s:%v", name, err)
+		}
+		if expected != response.Proxied {
+			t.Fatalf("%s:expected proxied=%v but got %v", name, expected, response.Proxied)
+		}
+		t.Logf("got proxied=%v for %s", response.Proxied, name)
+	}
+	check("direct", proxyPort, false)
+	check("haProxyPortV1", haProxyPortV1, true)
+	check("haProxyPortV2", haProxyPortV2, true)
+
+}

--- a/inttests/multiple_proxies_test.go
+++ b/inttests/multiple_proxies_test.go
@@ -16,6 +16,7 @@ import (
 */
 
 func TestCommonProxyProtocolInt(t *testing.T) {
+	t.Skip("skipping until EVG builds have HAProxy")
 	type mongonetIsConnectionProxiedResponse struct {
 		Proxied bool `bson:"proxied"`
 	}

--- a/inttests/pinnedServer_test.go
+++ b/inttests/pinnedServer_test.go
@@ -14,7 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
-func TestPinnedServer(t *testing.T) {
+func TestCommonPinnedServer(t *testing.T) {
 	mongoPort, proxyPort, hostname := util.GetTestHostAndPorts()
 	pc := getProxyConfig(hostname, mongoPort, proxyPort, DefaultMaxPoolSize, DefaultMaxPoolIdleTimeSec, util.Cluster, false, nil)
 	pc.LogLevel = slogger.DEBUG

--- a/inttests/run_integration_tests_mongod_mode.sh
+++ b/inttests/run_integration_tests_mongod_mode.sh
@@ -15,4 +15,3 @@ mkdir dbpath || true
 $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath --logpath `pwd`/dbpath/mongod.log --fork --setParameter enableTestCommands=1
 
 go test -test.v -run TestProxyMongodMode
-go test -test.v -run TestCommon

--- a/inttests/run_integration_tests_mongod_mode.sh
+++ b/inttests/run_integration_tests_mongod_mode.sh
@@ -15,5 +15,4 @@ mkdir dbpath || true
 $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath --logpath `pwd`/dbpath/mongod.log --fork --setParameter enableTestCommands=1
 
 go test -test.v -run TestProxyMongodMode
-
- 
+go test -test.v -run TestCommon

--- a/inttests/run_integration_tests_mongos_mode.sh
+++ b/inttests/run_integration_tests_mongos_mode.sh
@@ -31,4 +31,5 @@ $MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest2', 'p
 sleep 10 # let replica sets reach steady state
 
 go test -test.v -run TestProxyMongosMode
+go test -test.v -run TestCommon
 

--- a/proxy.go
+++ b/proxy.go
@@ -290,6 +290,6 @@ func (p *Proxy) CreateWorker(session *Session) (ServerWorker, error) {
 	return ps, nil
 }
 
-func (p *Proxy) GetConnection(conn net.Conn) io.ReadWriteCloser {
+func (p *Proxy) GetConnection(conn *Conn) io.ReadWriteCloser {
 	return conn
 }

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -159,7 +160,7 @@ func (s *Server) Run() error {
 	}()
 
 	type accepted struct {
-		conn net.Conn
+		conn Conn
 		err  error
 	}
 
@@ -168,7 +169,8 @@ func (s *Server) Run() error {
 	for {
 		go func() {
 			conn, err := ln.Accept()
-			incomingConnections <- accepted{conn, err}
+			wrapper, err2 := NewConn(conn)
+			incomingConnections <- accepted{*wrapper, MergeErrors(err, err2)}
 		}()
 
 		select {
@@ -177,13 +179,18 @@ func (s *Server) Run() error {
 			s.sessionManager.stopSessions()
 			return nil
 		case connectionEvent := <-incomingConnections:
-
 			if connectionEvent.err != nil {
 				return NewStackErrorf("could not accept in proxy: %s", err)
 			}
 			conn := connectionEvent.conn
+			if conn.IsProxied() {
+				s.logger.Logf(slogger.DEBUG, "accepted a proxied connection (local=%v, remote=%v, proxy=%v, target=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.ProxyAddr(), conn.TargetAddr())
+			} else {
+				s.logger.Logf(slogger.DEBUG, "accepted a regular connection (local=%v, remote=%v, target=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.TargetAddr())
+			}
+			wrappedConn := conn.wrapped
 			if s.config.TCPKeepAlivePeriod > 0 {
-				switch conn := conn.(type) {
+				switch conn := wrappedConn.(type) {
 				case *net.TCPConn:
 					conn.SetKeepAlive(true)
 					conn.SetKeepAlivePeriod(s.config.TCPKeepAlivePeriod)
@@ -194,16 +201,16 @@ func (s *Server) Run() error {
 
 			if s.config.UseSSL {
 				tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
-				conn = tls.Server(conn, tlsConfig)
+				wrappedConn = tls.Server(wrappedConn, tlsConfig)
 			}
 
-			remoteAddr := conn.RemoteAddr()
+			remoteAddr := connectionEvent.conn.RemoteAddr()
 			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), "", nil}
 			if _, ok := s.contextualWorkerFactory(); ok {
 				s.sessionManager.sessionWG.Add(1)
 			}
 
-			go c.Run(conn)
+			go c.Run(wrappedConn)
 		}
 
 	}
@@ -252,4 +259,29 @@ func NewServer(config ServerConfig, factory ServerWorkerFactory) Server {
 func (s *Server) contextualWorkerFactory() (ServerWorkerWithContextFactory, bool) {
 	swf, ok := s.workerFactory.(ServerWorkerWithContextFactory)
 	return swf, ok
+}
+
+func MergeErrors(errors ...error) error {
+	n, laste := 0, error(nil)
+
+	for _, e := range errors {
+		if e != nil {
+			n++
+			laste = e
+		}
+	}
+	switch n {
+	case 0:
+		return nil
+	case 1:
+		return laste
+	default:
+		s := make([]string, 0, n)
+		for _, e := range errors {
+			if e != error(nil) {
+				s = append(s, e.Error())
+			}
+		}
+		return fmt.Errorf("Multiple errors: %v", strings.Join(s, "; "))
+	}
 }

--- a/server.go
+++ b/server.go
@@ -31,7 +31,7 @@ func (s *SyncTlsConfig) getTlsConfig() *tls.Config {
 	return s.tlsConfig
 }
 
-func (s *SyncTlsConfig) setTlsConfig(sslKeys []*SSLPair, cipherSuites []uint16, minTlsVersion uint16, fallbackKeys []SSLPair) (ok bool, names []string, errs []error) {
+func (s *SyncTlsConfig) SetTlsConfig(sslKeys []*SSLPair, cipherSuites []uint16, minTlsVersion uint16, fallbackKeys []SSLPair) (ok bool, names []string, errs []error) {
 	ok = true
 	certs := []tls.Certificate{}
 	for _, pair := range fallbackKeys {
@@ -130,7 +130,7 @@ type Server struct {
 
 // called by a synched method
 func (s *Server) OnSSLConfig(sslPairs []*SSLPair) (ok bool, names []string, errs []error) {
-	return s.config.SyncTlsConfig.setTlsConfig(sslPairs, s.config.CipherSuites, s.config.MinTlsVersion, s.config.SSLKeys)
+	return s.config.SyncTlsConfig.SetTlsConfig(sslPairs, s.config.CipherSuites, s.config.MinTlsVersion, s.config.SSLKeys)
 }
 
 func (s *Server) Run() error {
@@ -202,6 +202,7 @@ func (s *Server) Run() error {
 			if s.config.UseSSL {
 				tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
 				conn.wrapped = tls.Server(conn, tlsConfig)
+				s.logger.Logf(slogger.DEBUG, "got a TLS connection") // TODO - remove
 			}
 
 			remoteAddr := connectionEvent.conn.RemoteAddr()

--- a/server.go
+++ b/server.go
@@ -201,7 +201,7 @@ func (s *Server) Run() error {
 
 			if s.config.UseSSL {
 				tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
-				wrappedConn = tls.Server(wrappedConn, tlsConfig)
+				conn.wrapped = tls.Server(wrappedConn, tlsConfig)
 			}
 
 			remoteAddr := connectionEvent.conn.RemoteAddr()

--- a/server.go
+++ b/server.go
@@ -201,7 +201,7 @@ func (s *Server) Run() error {
 
 			if s.config.UseSSL {
 				tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
-				conn.wrapped = tls.Server(wrappedConn, tlsConfig)
+				conn.wrapped = tls.Server(conn, tlsConfig)
 			}
 
 			remoteAddr := connectionEvent.conn.RemoteAddr()

--- a/server.go
+++ b/server.go
@@ -184,7 +184,7 @@ func (s *Server) Run() error {
 			}
 			conn := connectionEvent.conn
 			if conn.IsProxied() {
-				s.logger.Logf(slogger.DEBUG, "accepted a proxied connection (local=%v, remote=%v, proxy=%v, target=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.ProxyAddr(), conn.TargetAddr())
+				s.logger.Logf(slogger.DEBUG, "accepted a proxied connection (local=%v, remote=%v, proxy=%v, target=%v, version=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.ProxyAddr(), conn.TargetAddr(), conn.Version())
 			} else {
 				s.logger.Logf(slogger.DEBUG, "accepted a regular connection (local=%v, remote=%v, target=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.TargetAddr())
 			}
@@ -205,7 +205,7 @@ func (s *Server) Run() error {
 			}
 
 			remoteAddr := connectionEvent.conn.RemoteAddr()
-			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), "", nil}
+			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), "", nil, conn.IsProxied()}
 			if _, ok := s.contextualWorkerFactory(); ok {
 				s.sessionManager.sessionWG.Add(1)
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -392,7 +392,7 @@ func TestServerWorkerWithContext(t *testing.T) {
 			0,
 			nil,
 			slogger.DEBUG,
-			nil,
+			[]slogger.Appender{slogger.StdOutAppender()},
 		},
 		&TestFactoryWithContext{&sessCtr},
 	)

--- a/server_test.go
+++ b/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -201,7 +200,6 @@ func (mss *MyServerSession) DoLoopTemp() {
 			mss.session.Logf(slogger.WARN, "error reading message: %s", err)
 			return
 		}
-
 		err, fatal := mss.handleMessage(m)
 		if err == nil && fatal {
 			panic(fmt.Errorf("should be impossible, no error but fatal"))
@@ -215,7 +213,6 @@ func (mss *MyServerSession) DoLoopTemp() {
 			if fatal {
 				return
 			}
-
 		}
 	}
 }
@@ -230,7 +227,7 @@ func (sf *MyServerTestFactory) CreateWorker(session *mongonet.Session) (mongonet
 	return &MyServerSession{&BaseServerSession{session, map[string][]bson.D{}}}, nil
 }
 
-func (sf *MyServerTestFactory) GetConnection(conn net.Conn) io.ReadWriteCloser {
+func (sf *MyServerTestFactory) GetConnection(conn *mongonet.Conn) io.ReadWriteCloser {
 	return conn
 }
 
@@ -309,7 +306,7 @@ func (sf *TestFactoryWithContext) CreateWorker(session *mongonet.Session) (mongo
 	return nil, fmt.Errorf("create worker not allowed with contextual worker factory")
 }
 
-func (sf *TestFactoryWithContext) GetConnection(conn net.Conn) io.ReadWriteCloser {
+func (sf *TestFactoryWithContext) GetConnection(conn *mongonet.Conn) io.ReadWriteCloser {
 	return conn
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -248,7 +248,7 @@ func TestServer(t *testing.T) {
 			0,
 			nil,
 			slogger.DEBUG,
-			nil,
+			[]slogger.Appender{slogger.StdOutAppender()},
 		},
 		&MyServerTestFactory{},
 	)

--- a/session.go
+++ b/session.go
@@ -21,11 +21,18 @@ type Session struct {
 
 	SSLServerName string
 	tlsConn       *tls.Conn
+
+	proxiedConnection bool
 }
 
 var ErrUnknownOpcode = errors.New("unknown opcode")
 
 // ------------------
+
+func (s *Session) IsProxied() bool {
+	return s.proxiedConnection
+}
+
 func (s *Session) Connection() io.ReadWriteCloser {
 	return s.conn
 }

--- a/session.go
+++ b/session.go
@@ -74,13 +74,16 @@ func (s *Session) Run(conn *Conn) {
 	switch c := conn.wrapped.(type) {
 	case *tls.Conn:
 		// we do this here so that we can get the SNI server name
+		s.logger.Logf(slogger.DEBUG, "performing TLS handshake!")
 		err = c.Handshake()
+		s.logger.Logf(slogger.DEBUG, "after handshake")
 		if err != nil {
 			s.logger.Logf(slogger.WARN, "error doing tls handshake %s", err)
 			return
 		}
 		s.tlsConn = c
 		s.SSLServerName = strings.TrimSuffix(c.ConnectionState().ServerName, ".")
+		s.logger.Logf(slogger.DEBUG, "handshake successful! SNI=%s", s.SSLServerName)
 	}
 
 	s.logger.Logf(slogger.INFO, "new connection SSLServerName [%s]", s.SSLServerName)

--- a/session.go
+++ b/session.go
@@ -46,7 +46,7 @@ func (s *Session) ReadMessage() (Message, error) {
 	return ReadMessage(s.conn)
 }
 
-func (s *Session) Run(conn net.Conn) {
+func (s *Session) Run(conn *Conn) {
 	var err error
 	s.conn = s.server.workerFactory.GetConnection(conn)
 
@@ -64,7 +64,7 @@ func (s *Session) Run(conn net.Conn) {
 		}
 	}()
 
-	switch c := conn.(type) {
+	switch c := conn.wrapped.(type) {
 	case *tls.Conn:
 		// we do this here so that we can get the SNI server name
 		err = c.Handshake()

--- a/session.go
+++ b/session.go
@@ -74,16 +74,13 @@ func (s *Session) Run(conn *Conn) {
 	switch c := conn.wrapped.(type) {
 	case *tls.Conn:
 		// we do this here so that we can get the SNI server name
-		s.logger.Logf(slogger.DEBUG, "performing TLS handshake!")
 		err = c.Handshake()
-		s.logger.Logf(slogger.DEBUG, "after handshake")
 		if err != nil {
 			s.logger.Logf(slogger.WARN, "error doing tls handshake %s", err)
 			return
 		}
 		s.tlsConn = c
 		s.SSLServerName = strings.TrimSuffix(c.ConnectionState().ServerName, ".")
-		s.logger.Logf(slogger.DEBUG, "handshake successful! SNI=%s", s.SSLServerName)
 	}
 
 	s.logger.Logf(slogger.INFO, "new connection SSLServerName [%s]", s.SSLServerName)

--- a/sock.go
+++ b/sock.go
@@ -1,6 +1,8 @@
 package mongonet
 
-import "io"
+import (
+	"io"
+)
 
 const MaxInt32 = 2147483647
 


### PR DESCRIPTION
This PR implements the proxy protocol so that we can retain the original client IP on connections that go through another layer of load balancer/proxy.

It also adds SSL tests for the proxy server.

Tested locally that TestCommonProxyProtocolInt passes.