### PR TITLE
Don't block accept with handshake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage.out
 .vscode/settings.json
 inttests/dbpath
+.idea

--- a/proxy.go
+++ b/proxy.go
@@ -195,11 +195,14 @@ func (p *Proxy) ClearRemoteConnection(rsName string, additionalGracePeriodSec in
 }
 
 func (p *Proxy) InitializeServer() {
+	serverCtx, serverCancelCtx := context.WithCancel(p.Context)
+
 	server := Server{
 		p.Config.ServerConfig,
 		p.logger,
 		p,
-		make(chan struct{}),
+		serverCtx,
+		serverCancelCtx,
 		make(chan error, 1),
 		make(chan struct{}),
 		nil,

--- a/server.go
+++ b/server.go
@@ -157,7 +157,12 @@ func (s *Server) Run() error {
 
 	defer func() {
 		ln.Close()
+
+		// add another context cancellation so that it happens now.
+		// Otherwise the prior deferred cancellation won't happen until
+		// after this defer call (because defers are called LIFO)
 		s.cancelCtx()
+
 		// wait for all sessions to end
 		s.logger.Logf(slogger.WARN, "waiting for sessions to close...")
 		s.sessionManager.sessionWG.Wait()

--- a/server.go
+++ b/server.go
@@ -179,11 +179,12 @@ func (s *Server) Run() error {
 	incomingConnections := make(chan accepted, 128)
 
 	go func() {
-		var conn net.Conn
-		var err error = nil
-		for err == nil {
-			conn, err = ln.Accept()
+		for {
+			conn, err := ln.Accept()
 			incomingConnections <- accepted{conn, err}
+			if err != nil {
+				return
+			}
 		}
 	}()
 

--- a/server.go
+++ b/server.go
@@ -102,26 +102,26 @@ type ServerWorkerFactory interface {
 }
 
 // ServerWorkerWithContextFactory should be used when workers need to listen to the Done channel of the session context.
-// The server will call stopSessions() when the server killChan is closed; stopSessions() will close the Done channel.
+// The server will cancel the ctx passed to CreateWorkerWithContext() when it exits; causing the ctx's Done channel to be closed
 // Implementing this interface will cause the server to incrememnt a session wait group when each new session starts.
 // A mongonet session will decrement the wait group after calling .Close() on the session.
 // When using this you should make sure that your `DoLoopTemp` returns when it receives from the context Done Channel.
 type ServerWorkerWithContextFactory interface {
 	ServerWorkerFactory
-	CreateWorkerWithContext(session *Session, ctx *context.Context) (ServerWorker, error)
+	CreateWorkerWithContext(session *Session, ctx context.Context) (ServerWorker, error)
 }
 
 type sessionManager struct {
-	sessionWG    *sync.WaitGroup
-	ctx          *context.Context
-	stopSessions context.CancelFunc
+	sessionWG *sync.WaitGroup
+	ctx       context.Context
 }
 
 type Server struct {
 	config         ServerConfig
 	logger         *slogger.Logger
 	workerFactory  ServerWorkerFactory
-	killChan       chan struct{}
+	ctx            context.Context
+	cancelCtx      context.CancelFunc
 	initChan       chan error
 	doneChan       chan struct{}
 	sessionManager *sessionManager
@@ -138,9 +138,15 @@ func (s *Server) Run() error {
 
 	s.logger.Logf(slogger.WARN, "listening on %s", bindTo)
 
+	defer s.cancelCtx()
 	defer close(s.initChan)
 
-	ln, err := net.Listen("tcp", bindTo)
+	keepAlive := time.Duration(-1)       // negative Duration means keep-alives disabled in ListenConfig
+	if s.config.TCPKeepAlivePeriod > 0 { // but in our config we use 0 to mean keep-alives are disabled
+		keepAlive = s.config.TCPKeepAlivePeriod
+	}
+	lc := &net.ListenConfig{KeepAlive: keepAlive}
+	ln, err := lc.Listen(s.ctx, "tcp", bindTo)
 	if err != nil {
 		returnErr := NewStackErrorf("cannot start listening in proxy: %s", err)
 		s.initChan <- returnErr
@@ -151,6 +157,7 @@ func (s *Server) Run() error {
 
 	defer func() {
 		ln.Close()
+		s.cancelCtx()
 		// wait for all sessions to end
 		s.logger.Logf(slogger.WARN, "waiting for sessions to close...")
 		s.sessionManager.sessionWG.Wait()
@@ -159,57 +166,69 @@ func (s *Server) Run() error {
 		close(s.doneChan)
 	}()
 
-	type accepted struct {
-		conn *Conn
-		err  error
-	}
-
-	incomingConnections := make(chan accepted, 1)
-
 	for {
-		go func() {
-			conn, err := ln.Accept()
-			if s.config.TCPKeepAlivePeriod > 0 {
-				switch conn := conn.(type) {
-				case *net.TCPConn:
-					conn.SetKeepAlive(true)
-					conn.SetKeepAlivePeriod(s.config.TCPKeepAlivePeriod)
-				default:
-					s.logger.Logf(slogger.WARN, "Want to set TCP keep alive on accepted connection but connection is not *net.TCPConn.  It is %T", conn)
-				}
+		conn, err := ln.Accept()
+		if err != nil {
+			if s.ctx.Err() != nil {
+				// context was cancelled.  Exit cleanly
+				return nil
 			}
-			if s.config.UseSSL {
-				tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
-				conn = tls.Server(conn, tlsConfig)
-			}
-			wrapper, err2 := NewConn(conn)
-			incomingConnections <- accepted{wrapper, MergeErrors(err, err2)}
-		}()
-
-		select {
-		case <-s.killChan:
-			// close the Done channel on the sessions ctx
-			s.sessionManager.stopSessions()
-			return nil
-		case connectionEvent := <-incomingConnections:
-			if connectionEvent.err != nil {
-				return NewStackErrorf("could not accept in proxy: %s", err)
-			}
-			conn := connectionEvent.conn
-			if conn.IsProxied() {
-				s.logger.Logf(slogger.DEBUG, "accepted a proxied connection (local=%v, remote=%v, proxy=%v, target=%v, version=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.ProxyAddr(), conn.TargetAddr(), conn.Version())
-			} else {
-				s.logger.Logf(slogger.DEBUG, "accepted a regular connection (local=%v, remote=%v, target=%v)", conn.LocalAddr(), conn.RemoteAddr(), conn.TargetAddr())
-			}
-			remoteAddr := connectionEvent.conn.RemoteAddr()
-			c := &Session{s, nil, remoteAddr, s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)), "", nil, conn.IsProxied()}
-			if _, ok := s.contextualWorkerFactory(); ok {
-				s.sessionManager.sessionWG.Add(1)
-			}
-			go c.Run(conn)
+			return NewStackErrorf("could not accept in proxy: %s", err)
 		}
 
+		go s.handleConnection(conn)
 	}
+
+}
+
+func (s *Server) handleConnection(conn net.Conn) {
+	if s.config.UseSSL {
+		tlsConfig := s.config.SyncTlsConfig.getTlsConfig()
+		conn = tls.Server(conn, tlsConfig)
+	}
+
+	proxyProtoConn, err := NewConn(conn)
+	if err != nil {
+		s.logger.Logf(slogger.ERROR, "Error setting up a proxy protocol compatible connection: %v", err)
+		conn.Close()
+		return
+	}
+
+	if proxyProtoConn.IsProxied() {
+		s.logger.Logf(
+			slogger.DEBUG,
+			"accepted a proxied connection (local=%v, remote=%v, proxy=%v, target=%v, version=%v)",
+			proxyProtoConn.LocalAddr(),
+			proxyProtoConn.RemoteAddr(),
+			proxyProtoConn.ProxyAddr(),
+			proxyProtoConn.TargetAddr(),
+			proxyProtoConn.Version(),
+		)
+	} else {
+		s.logger.Logf(
+			slogger.DEBUG,
+			"accepted a regular connection (local=%v, remote=%v)",
+			conn.LocalAddr(),
+			conn.RemoteAddr(),
+		)
+	}
+
+	remoteAddr := conn.RemoteAddr()
+	c := &Session{
+		s,
+		nil,
+		remoteAddr,
+		s.NewLogger(fmt.Sprintf("Session %s", remoteAddr)),
+		"",
+		nil,
+		proxyProtoConn.IsProxied(),
+	}
+
+	if _, ok := s.contextualWorkerFactory(); ok {
+		s.sessionManager.sessionWG.Add(1)
+	}
+
+	c.Run(proxyProtoConn)
 }
 
 // InitChannel returns a channel that will send nil once the server has started
@@ -219,7 +238,7 @@ func (s *Server) InitChannel() <-chan error {
 }
 
 func (s *Server) Close() {
-	close(s.killChan)
+	s.cancelCtx()
 	<-s.doneChan
 }
 
@@ -235,18 +254,18 @@ func (s *Server) NewLogger(prefix string) *slogger.Logger {
 }
 
 func NewServer(config ServerConfig, factory ServerWorkerFactory) Server {
-	sessionCtx, stopSessions := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(context.Background())
 	return Server{
 		config,
 		&slogger.Logger{"Server", config.Appenders, 0, nil},
 		factory,
-		make(chan struct{}),
+		ctx,
+		cancelCtx,
 		make(chan error, 1),
 		make(chan struct{}),
 		&sessionManager{
 			&sync.WaitGroup{},
-			&sessionCtx,
-			stopSessions,
+			ctx,
 		},
 		nil,
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -356,7 +356,7 @@ type TestFactoryWithContext struct {
 	counter *int32
 }
 
-func (sf *TestFactoryWithContext) CreateWorkerWithContext(session *mongonet.Session, ctx *context.Context) (mongonet.ServerWorker, error) {
+func (sf *TestFactoryWithContext) CreateWorkerWithContext(session *mongonet.Session, ctx context.Context) (mongonet.ServerWorker, error) {
 	return &TestSessionWithContext{&BaseServerSession{session, map[string][]bson.D{}}, ctx, sf.counter}, nil
 }
 
@@ -370,13 +370,13 @@ func (sf *TestFactoryWithContext) GetConnection(conn *mongonet.Conn) io.ReadWrit
 
 type TestSessionWithContext struct {
 	*BaseServerSession
-	ctx     *context.Context
+	ctx     context.Context
 	counter *int32
 }
 
 func (tsc *TestSessionWithContext) DoLoopTemp() {
 	atomic.AddInt32(tsc.counter, 1)
-	ctx := *tsc.ctx
+	ctx := tsc.ctx
 
 	for {
 		m, err := tsc.session.ReadMessage()

--- a/session.go
+++ b/session.go
@@ -73,12 +73,7 @@ func (s *Session) Run(conn *Conn) {
 
 	switch c := conn.wrapped.(type) {
 	case *tls.Conn:
-		// we do this here so that we can get the SNI server name
-		err = c.Handshake()
-		if err != nil {
-			s.logger.Logf(slogger.WARN, "error doing tls handshake %s", err)
-			return
-		}
+		// Handshake has already happened
 		s.tlsConn = c
 		s.SSLServerName = strings.TrimSuffix(c.ConnectionState().ServerName, ".")
 	}


### PR DESCRIPTION
Evergreen: https://spruce.mongodb.com/version/60c39a7a30661513157d4fba/tasks

This moves the now implied TLS handshake out of the Accept loop so that it does not block getting to the next incoming connection.  Tomer, I discovered that despite configuring a ListenConfig with a context, it is not being used with Accept.  So I had to keep Accept in a separate goroutine.  However, now the goroutine is persistent rather than spawning a new one for every Accept.

Martin, I've simplified some code around here that I believe you touched a few years ago.  Namely, I simplified context cancellation.  So I'm just asking for a sanity check here on stuff I touched that Stitch may be interested in.