### PR TITLE
Run raw command API

### DIFF
--- a/inttests/mongoapi_test.go
+++ b/inttests/mongoapi_test.go
@@ -1,0 +1,38 @@
+package inttests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mongodb/mongonet"
+	"github.com/mongodb/mongonet/util"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestCommonRunCommandUsingRawBSON(t *testing.T) {
+	mongoPort, _, hostname := util.GetTestHostAndPorts()
+	goctx := context.Background()
+	client, err := util.GetTestClient(hostname, mongoPort, util.Direct, false, "mongoapi_tester", goctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Disconnect(goctx)
+
+	cmd := bson.D{{"ping", 1}, {"$db", "admin"}}
+	response, err := mongonet.RunCommandUsingRawBSON(cmd, client, goctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := response.Map()["ok"]
+	if !ok {
+		t.Fatalf("expected to find 'ok' in response %+v", raw)
+	}
+	v, ok := raw.(float64)
+	if !ok {
+		t.Fatalf("expected to that 'ok' is int but got %T", raw)
+	}
+	if v != 1 {
+		t.Fatalf("expected to get ok:1 but got %v", v)
+	}
+
+}

--- a/inttests/run_integration_tests_mongod_mode.sh
+++ b/inttests/run_integration_tests_mongod_mode.sh
@@ -15,5 +15,6 @@ mkdir dbpath || true
 $MONGO_DIR/mongod --port $MONGO_PORT --dbpath `pwd`/dbpath --logpath `pwd`/dbpath/mongod.log --fork --setParameter enableTestCommands=1
 
 go test -test.v -run TestProxyMongodMode
+go test -test.v -run TestCommon
 
  

--- a/inttests/run_integration_tests_mongos_mode.sh
+++ b/inttests/run_integration_tests_mongos_mode.sh
@@ -31,4 +31,4 @@ $MONGO_DIR/mongo --port $MONGO_PORT --eval "rs.initiate({'_id': 'proxytest2', 'p
 sleep 10 # let replica sets reach steady state
 
 go test -test.v -run TestProxyMongosMode
-
+go test -test.v -run TestCommon

--- a/mongoapi.go
+++ b/mongoapi.go
@@ -1,0 +1,74 @@
+package mongonet
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+// RunCommandUsingRawBSON - runs a command using low-level writeWireMessage API
+// Notes:
+// 1. caller is expected to cleanup mongo.Client object
+// 2. Uses primary read preference
+// 3. Expects an OP_MSG response back from the server
+func RunCommandUsingRawBSON(cmd bson.D, client *mongo.Client, goctx context.Context) (bson.D, error) {
+	topology := extractTopology(client)
+	srv, err := topology.SelectServer(goctx, description.ReadPrefSelector(readpref.Primary()))
+	if err != nil {
+		return nil, err
+	}
+	conn, err := srv.Connection(goctx)
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := SimpleBSONConvert(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	newmsg := &MessageMessage{
+		MessageHeader{
+			0,
+			17,
+			1,
+			OP_MSG},
+		0,
+		[]MessageMessageSection{
+			&BodySection{
+				sb,
+			},
+		},
+	}
+
+	if err := conn.WriteWireMessage(goctx, newmsg.Serialize()); err != nil {
+		return nil, err
+	}
+
+	ret, err := conn.ReadWireMessage(goctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := ReadMessageFromBytes(ret)
+	if err != nil {
+		return nil, err
+	}
+	if mm, ok := resp.(*MessageMessage); ok {
+		for _, sec := range mm.Sections {
+			if bodySection, ok := sec.(*BodySection); ok && bodySection != nil {
+				respBsonD, err := bodySection.Body.ToBSOND()
+				if err != nil {
+					return nil, err
+				}
+				return respBsonD, nil
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("expected an OP_MSG response but got %T", resp)
+	}
+	return nil, fmt.Errorf("couldn't find a body section in response")
+}


### PR DESCRIPTION
This PR adds the ability to send OP_MSG over a low level API so that lsid can be explicitly set

I ran the int tests locally and verified they pass. EVG is currently pointed at the master branch, so #82 should indicate if they pass on master.