### PR TITLE
Update ResponseInterceptor Interface to ProcessExecutionStats

### DIFF
--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -60,6 +60,10 @@ type FindFixer struct {
 	cm              *LightCursorManager
 }
 
+func (ff *FindFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTime int64) {
+	// no-op
+}
+
 func (ff *FindFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool) (Message, error) {
 	switch mm := m.(type) {
 	case *MessageMessage:
@@ -148,6 +152,10 @@ func fixHostNames(doc bson.D, old, new int) bson.D {
 func fixIsMasterDirect(doc bson.D, mongoPort, proxyPort int) (SimpleBSON, error) {
 	doc = fixHostNames(doc, mongoPort, proxyPort)
 	return SimpleBSONConvert(doc)
+}
+
+func (mri *IsMasterFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTime int64) {
+	// no-op
 }
 
 func (mri *IsMasterFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool) (Message, error) {

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -60,7 +60,7 @@ type FindFixer struct {
 	cm              *LightCursorManager
 }
 
-func (ff *FindFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
+func (ff *FindFixer) ProcessExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
 	// no-op
 }
 
@@ -154,7 +154,7 @@ func fixIsMasterDirect(doc bson.D, mongoPort, proxyPort int) (SimpleBSON, error)
 	return SimpleBSONConvert(doc)
 }
 
-func (mri *IsMasterFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
+func (mri *IsMasterFixer) ProcessExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
 	// no-op
 }
 

--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -60,7 +60,7 @@ type FindFixer struct {
 	cm              *LightCursorManager
 }
 
-func (ff *FindFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTime int64) {
+func (ff *FindFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
 	// no-op
 }
 
@@ -154,7 +154,7 @@ func fixIsMasterDirect(doc bson.D, mongoPort, proxyPort int) (SimpleBSON, error)
 	return SimpleBSONConvert(doc)
 }
 
-func (mri *IsMasterFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTime int64) {
+func (mri *IsMasterFixer) ExtractExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64) {
 	// no-op
 }
 

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -47,6 +47,7 @@ type MetricsHookFactory interface {
 
 type ResponseInterceptor interface {
 	InterceptMongoToClient(m Message, serverAddress address.Address, isRemote bool) (Message, error)
+	ExtractExecutionTime(startTime time.Time, pausedExecutionTime int64)
 }
 
 type ProxyInterceptor interface {
@@ -413,9 +414,15 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper, retryError *Pr
 	ps.logMessageTrace(ps.proxy.logger, ps.proxy.Config.TraceConnPool, m)
 	var respInter ResponseInterceptor
 	var pinnedAddress address.Address
+	pausedExecutionTime := int64(0)
 	if ps.interceptor != nil {
 		ps.interceptor.TrackRequest(m.Header())
 		m, respInter, remoteRs, pinnedAddress, err = ps.interceptor.InterceptClientToMongo(m, previousRes)
+		defer func () {
+			if respInter != nil {
+				respInter.ExtractExecutionTime(startServerSelection, pausedExecutionTime)
+			}
+		}()
 		if err != nil {
 			if m == nil {
 				if ps.isMetricsEnabled {
@@ -636,6 +643,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper, retryError *Pr
 
 		// Send message back to user
 		ps.logTrace(ps.proxy.logger, ps.proxy.Config.TraceConnPool, "sending back data to user from mongo conn id=%v remoteRs=%s", mongoConn.conn.ID(), remoteRs)
+		startPausedTimer := time.Now()
 		err = SendMessage(resp, ps.conn)
 		if err != nil {
 			if ps.isMetricsEnabled {
@@ -676,6 +684,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper, retryError *Pr
 			}
 			return nil, NewStackErrorf("bad response type from server %T", r)
 		}
+		pausedExecutionTime += time.Now().Sub(startPausedTimer).Microseconds()
 	}
 }
 

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -418,7 +418,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper, retryError *Pr
 	if ps.interceptor != nil {
 		ps.interceptor.TrackRequest(m.Header())
 		m, respInter, remoteRs, pinnedAddress, err = ps.interceptor.InterceptClientToMongo(m, previousRes)
-		defer func () {
+		defer func() {
 			if respInter != nil {
 				respInter.ExtractExecutionTime(startServerSelection, pausedExecutionTime)
 			}

--- a/proxy_session.go
+++ b/proxy_session.go
@@ -47,9 +47,9 @@ type MetricsHookFactory interface {
 
 type ResponseInterceptor interface {
 	InterceptMongoToClient(m Message, serverAddress address.Address, isRemote bool) (Message, error)
-	// ExtractExecutionTime records the execution time of an operation from startTime, subtracting
+	// ProcessExecutionTime records the execution time of an operation from startTime, subtracting
 	// time while execution was paused, pausedExecutionTimeMicros (i.e. while sending the message back to client)
-	ExtractExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64)
+	ProcessExecutionTime(startTime time.Time, pausedExecutionTimeMicros int64)
 }
 
 type ProxyInterceptor interface {
@@ -422,7 +422,7 @@ func (ps *ProxySession) doLoop(mongoConn *MongoConnectionWrapper, retryError *Pr
 		m, respInter, remoteRs, pinnedAddress, err = ps.interceptor.InterceptClientToMongo(m, previousRes)
 		defer func() {
 			if respInter != nil {
-				respInter.ExtractExecutionTime(startServerSelection, pausedExecutionTimeMicros)
+				respInter.ProcessExecutionTime(startServerSelection, pausedExecutionTimeMicros)
 			}
 		}()
 		if err != nil {


### PR DESCRIPTION
Update the ResponseInterceptor interface to include ExtractExecutionStats. An initial timestamp will be taken once a This should account for the following edge cases: 
- responseInterceptor is `nil`
- responseInterceptor is not used since proxy returns message itself (CMD_I_HANDLE)

Evergreen patch for mongonet: 
https://evergreen.mongodb.com/version/60d5f2f90ae60671e32d0f5d

Evergreen patch for proxy will fail because of update to the ResponseInterceptor interface. Will put up a PR shortly in the proxy repo with changes that allow those to pass