### PR TITLE
[WIP] Extend retry API to allow multiple retries before return

### DIFF
--- a/inttests/int_test_utils.go
+++ b/inttests/int_test_utils.go
@@ -64,7 +64,7 @@ func (ff *FindFixer) ProcessExecutionTime(startTime time.Time, pausedExecutionTi
 	// no-op
 }
 
-func (ff *FindFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool) (Message, error) {
+func (ff *FindFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool, retryFailed bool) (Message, error) {
 	switch mm := m.(type) {
 	case *MessageMessage:
 		doc, _, err := MessageMessageToBSOND(mm)
@@ -158,7 +158,7 @@ func (mri *IsMasterFixer) ProcessExecutionTime(startTime time.Time, pausedExecut
 	// no-op
 }
 
-func (mri *IsMasterFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool) (Message, error) {
+func (mri *IsMasterFixer) InterceptMongoToClient(m Message, address address.Address, isRemote bool, retryFailed bool) (Message, error) {
 	switch mm := m.(type) {
 	case *ReplyMessage:
 		var err error

--- a/util.go
+++ b/util.go
@@ -17,6 +17,7 @@ type ProxyRetryError struct {
 	MsgToRetry     Message
 	PreviousResult SimpleBSON
 	RetryOnRs      string
+	RetryCount     int
 }
 
 func (e *ProxyRetryError) Error() string {
@@ -28,6 +29,20 @@ func NewProxyRetryError(msgToRetry Message, previousRes SimpleBSON, retryOnRs st
 		msgToRetry,
 		previousRes,
 		retryOnRs,
+		1,
+	}
+}
+
+// NewProxyRetryErrorWithRetryCount returns a ProxyRetryError with retryCount
+// number of retries. This is the same as NewProxyRetryError with retryCount
+// set to 1. If the retry fails (non-zero errorCode) retryCount number of times
+// we will return the error back to the proxy.
+func NewProxyRetryErrorWithRetryCount(msgToRetry Message, previousRes SimpleBSON, retryOnRs string, retryCount int) *ProxyRetryError {
+	return &ProxyRetryError{
+		msgToRetry,
+		previousRes,
+		retryOnRs,
+		retryCount,
 	}
 }
 


### PR DESCRIPTION
We extend the ProxyRetryError API to allow the Proxy to specify a count for the number of times we can attempt to retry the command. We also extend InterceptClientToMongo to return a bool (retryFailed) which allows mongonet to specify to the proxy that the last command was a result of a failed retry (so we can send the error back to the user rather than retrying again).